### PR TITLE
Fix for zig3 er rule

### DIFF
--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -3290,7 +3290,7 @@ namespace TunicRandomizer {
                         "Rooted Ziggurat Lower Front",
                         new List<List<string>> {
                             new List<string> {
-                                "Hyperdash",
+                                "Hyperdash", "Sword", "12"
                             },
                             new List<string> {
                                 "Ladder Storage",


### PR DESCRIPTION
I thought you could go backwards with just laurels, but you trigger the double admin fight along the way which drops the bridge, and you can't laurels across that bridge.

Adds sword and prayer requirement (since you need prayer to bring the bridge back up)