### PR TITLE
Fix atoll regions

### DIFF
--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -493,6 +493,11 @@ namespace TunicRandomizer {
                         "Ruined Atoll Portal",
                         new List<TunicPortal> {
                             new TunicPortal("Atoll to Far Shore", "Transit_teleporter_atoll"),
+                        }
+                    },
+                    {
+                        "Ruined Atoll Statue",
+                        new List<TunicPortal> {
                             new TunicPortal("Atoll Statue Teleporter", "Library Exterior_"),
                         }
                     },
@@ -1550,6 +1555,10 @@ namespace TunicRandomizer {
                 new RegionInfo("Atoll Redux", false)
             },
             {
+                "Ruined Atoll Statue",
+                new RegionInfo("Atoll Redux", false)
+            },
+            {
                 "Frog's Domain Entry",
                 new RegionInfo("Frog Stairs", false)
             },
@@ -2543,6 +2552,14 @@ namespace TunicRandomizer {
                             },
                         }
                     },
+                    {
+                        "Ruined Atoll Statue",
+                        new List<List<string>> {
+                            new List<string> {
+                                "12",
+                            },
+                        }
+                    },
                 }
             },
             {
@@ -2579,6 +2596,16 @@ namespace TunicRandomizer {
             },
             {
                 "Ruined Atoll Portal",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Ruined Atoll",
+                        new List<List<string>> {
+                        }
+                    },
+                }
+            },
+            {
+                "Ruined Atoll Statue",
                 new Dictionary<string, List<List<string>>> {
                     {
                         "Ruined Atoll",


### PR DESCRIPTION
Statue teleporter and portal pad were in the same region for convenience. This was not a great idea, as if you had access to one, it assumed you had access to the other, regardless of whether you have prayer.
Splits them into separate regions.