### PR TITLE
Update ER to add the ladder regions

### DIFF
--- a/src/Data/Check.cs
+++ b/src/Data/Check.cs
@@ -49,6 +49,10 @@ namespace TunicRandomizer {
                         if (ItemRandomizer.testBool) {
                             TunicRandomizer.Logger.LogInfo("LocationID is " + this.LocationId);
                             TunicRandomizer.Logger.LogInfo("inventory does not contain " + item);
+                            TunicRandomizer.Logger.LogInfo("full inventory is ");
+                            foreach (string thing in inventory.Keys) {
+                                TunicRandomizer.Logger.LogInfo(thing);
+                            }
                         }
                         break;
                     } else if (inventory[item] >= req[item]) {

--- a/src/Data/Check.cs
+++ b/src/Data/Check.cs
@@ -49,10 +49,6 @@ namespace TunicRandomizer {
                         if (ItemRandomizer.testBool) {
                             TunicRandomizer.Logger.LogInfo("LocationID is " + this.LocationId);
                             TunicRandomizer.Logger.LogInfo("inventory does not contain " + item);
-                            TunicRandomizer.Logger.LogInfo("full inventory is ");
-                            foreach (string thing in inventory.Keys) {
-                                TunicRandomizer.Logger.LogInfo(thing);
-                            }
                         }
                         break;
                     } else if (inventory[item] >= req[item]) {

--- a/src/Data/ItemListJson.cs
+++ b/src/Data/ItemListJson.cs
@@ -222,7 +222,7 @@
                     ""Position"": ""(26.0, 28.0, -116.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1}
+                        {""Above Ruined Passage"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -296,7 +296,7 @@
                     ""Position"": ""(79.3, 2.5, -173.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1}
+                        {""Overworld Swamp Lower Entry"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -368,7 +368,7 @@
                     ""Position"": ""(96.5, 28.0, -137.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1}
+                        {""East Overworld"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -387,7 +387,7 @@
                         {""21"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1, ""21"": 1}
+                        {""East Overworld"": 1, ""21"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -404,7 +404,7 @@
                     ""Position"": ""(54.0, 48.8, -90.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1}
+                        {""East Overworld"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -629,7 +629,7 @@
                     ""Position"": ""(162.2, 0.1, -8.5)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Guard House 2"": 1}
+                        {""Guard House 2 Upper"": 1}
                     ],
                     ""SceneId"": 54,
                     ""SceneName"": ""East Forest Redux Interior""
@@ -646,7 +646,7 @@
                     ""Position"": ""(193.9, -32.0, -23.8)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Guard House 2"": 1}
+                        {""Guard House 2 Lower"": 1}
                     ],
                     ""SceneId"": 54,
                     ""SceneName"": ""East Forest Redux Interior""
@@ -663,7 +663,7 @@
                     ""Position"": ""(91.0, -26.0, -58.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""East Forest"": 1}
+                        {""Lower Forest"": 1}
                     ],
                     ""SceneId"": 53,
                     ""SceneName"": ""East Forest Redux""
@@ -680,7 +680,7 @@
                     ""Position"": ""(88.0, -30.5, -59.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""East Forest"": 1}
+                        {""Lower Forest"": 1}
                     ],
                     ""SceneId"": 53,
                     ""SceneName"": ""East Forest Redux""
@@ -699,7 +699,7 @@
                         {""21"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""East Forest"": 1, ""21"": 1}
+                        {""Lower Forest"": 1, ""21"": 1}
                     ],
                     ""SceneId"": 53,
                     ""SceneName"": ""East Forest Redux""
@@ -718,7 +718,7 @@
                         {""Wand"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Wand"": 1, ""East Forest"": 1}
+                        {""Wand"": 1, ""Lower Forest"": 1}
                     ],
                     ""SceneId"": 53,
                     ""SceneName"": ""East Forest Redux""
@@ -737,7 +737,7 @@
                         {""Wand"": 1, ""Hyperdash"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Wand"": 1, ""Hyperdash"": 1, ""East Forest"": 1}
+                        {""Wand"": 1, ""Hyperdash"": 1, ""Lower Forest"": 1}
                     ],
                     ""SceneId"": 53,
                     ""SceneName"": ""East Forest Redux""
@@ -911,7 +911,7 @@
                         {""21"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1, ""21"": 1}
+                        {""East Overworld"": 1, ""21"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -964,7 +964,7 @@
                     ""Position"": ""(67.0, 66.0, 22.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1}
+                        {""Upper Overworld"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -981,7 +981,7 @@
                     ""Position"": ""(-95.0, 73.0, 46.2)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1}
+                        {""Upper Overworld"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -1000,7 +1000,7 @@
                         {""21"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1, ""21"": 1}
+                        {""Upper Overworld"": 1, ""21"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -1017,7 +1017,7 @@
                     ""Position"": ""(-111.7, 66.0, 38.2)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1}
+                        {""Overworld above Quarry Entrance"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -1390,7 +1390,7 @@
                     ""Position"": ""(-33.3, 0.3, -169.8)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1}
+                        {""Overworld Beach"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -1409,7 +1409,7 @@
                         {""21"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1, ""21"": 1}
+                        {""Overworld Beach"": 1, ""21"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -1428,7 +1428,7 @@
                         {""21"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1, ""21"": 1}
+                        {""Overworld Beach"": 1, ""21"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -1445,7 +1445,7 @@
                     ""Position"": ""(-83.2, 4.0, -177.1)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1}
+                        {""Overworld Beach"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -1481,7 +1481,7 @@
                         {""21"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Hourglass Cave"": 1, ""21"": 1}
+                        {""Hourglass Cave Tower"": 1, ""21"": 1}
                     ],
                     ""SceneId"": 7,
                     ""SceneName"": ""Town Basement""
@@ -1498,7 +1498,7 @@
                     ""Position"": ""(-130.0, 12.0, -119.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1}
+                        {""Overworld Tunnel Turret"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -1515,7 +1515,7 @@
                     ""Position"": ""(65.0, 22.0, -138.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1}
+                        {""After Ruined Passage"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -1532,7 +1532,7 @@
                     ""Position"": ""(-161.0, 1.0, -72.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1}
+                        {""Overworld Beach"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -1552,8 +1552,8 @@
                         {""Wand"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Hyperdash"": 1, ""Overworld"": 1},
-                        {""Wand"": 1, ""Overworld"": 1}
+                        {""Hyperdash"": 1, ""Overworld Beach"": 1},
+                        {""Wand"": 1, ""Overworld Beach"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -1570,7 +1570,7 @@
                     ""Position"": ""(-3.0, 1.5, -152.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1}
+                        {""Overworld Beach"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -1678,7 +1678,7 @@
                     ""Position"": ""(15.5, 1.0, -147.5)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1}
+                        {""Overworld Beach"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -1731,7 +1731,7 @@
                     ""Position"": ""(-7.0, 16.9, -72.3)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Ruined Atoll"": 1}
+                        {""Ruined Atoll Ladder Tops"": 1}
                     ],
                     ""SceneId"": 32,
                     ""SceneName"": ""Atoll Redux""
@@ -1748,7 +1748,7 @@
                     ""Position"": ""(38.0, 16.0, -72.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Ruined Atoll"": 1}
+                        {""Ruined Atoll Ladder Tops"": 1}
                     ],
                     ""SceneId"": 32,
                     ""SceneName"": ""Atoll Redux""
@@ -1782,7 +1782,7 @@
                     ""Position"": ""(71.8, 13.0, -44.3)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Ruined Atoll"": 1}
+                        {""Ruined Atoll Ladder Tops"": 1}
                     ],
                     ""SceneId"": 32,
                     ""SceneName"": ""Atoll Redux""
@@ -2789,7 +2789,7 @@
                     ""Position"": ""(-138.2, 28.0, 10.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Overworld"": 1}
+                        {""Overworld after Envoy"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -2808,7 +2808,7 @@
                         {""Lantern"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Lantern"": 1, ""Dark Tomb Main"": 1}
+                        {""Lantern"": 1, ""Dark Tomb Upper"": 1}
                     ],
                     ""SceneId"": 64,
                     ""SceneName"": ""Crypt Redux""
@@ -3376,7 +3376,7 @@
                         {""Hyperdash"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Hyperdash"": 1, ""Overworld"": 1}
+                        {""Hyperdash"": 1, ""Overworld Beach"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -3477,7 +3477,7 @@
                         {""Wand"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Wand"": 1, ""Overworld"": 1}
+                        {""Wand"": 1, ""Overworld above Patrol Cave"": 1}
                     ],
                     ""SceneId"": 25,
                     ""SceneName"": ""Overworld Redux""
@@ -4240,7 +4240,7 @@
                         {""Mask"": 1, ""Techbow"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Mask"": 1, ""Lower Quarry"": 1}
+                        {""Mask"": 1, ""Even Lower Quarry"": 1}
                     ],
                     ""SceneId"": 60,
                     ""SceneName"": ""Quarry Redux""
@@ -4260,7 +4260,7 @@
                         {""Mask"": 1, ""Techbow"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Mask"": 1, ""Lower Quarry"": 1}
+                        {""Mask"": 1, ""Even Lower Quarry"": 1}
                     ],
                     ""SceneId"": 60,
                     ""SceneName"": ""Quarry Redux""
@@ -4280,7 +4280,7 @@
                         {""Mask"": 1, ""Techbow"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Mask"": 1, ""Lower Quarry"": 1}
+                        {""Mask"": 1, ""Even Lower Quarry"": 1}
                     ],
                     ""SceneId"": 60,
                     ""SceneName"": ""Quarry Redux""
@@ -4794,7 +4794,7 @@
                     ""Position"": ""(-47.7, -1.5, -33.3)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Front"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -4811,7 +4811,7 @@
                     ""Position"": ""(-41.6, -0.6, 55.4)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Front"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -4828,7 +4828,7 @@
                     ""Position"": ""(14.5, 0.0, -73.5)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Front"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -4845,7 +4845,7 @@
                     ""Position"": ""(39.2, -0.1, -85.3)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Front"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -4862,7 +4862,7 @@
                     ""Position"": ""(83.7, 0.0, -73.8)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Front"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -4879,7 +4879,7 @@
                     ""Position"": ""(166.0, 0.0, -82.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Front"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -4896,7 +4896,7 @@
                     ""Position"": ""(147.0, 5.8, -33.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Front"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -4913,7 +4913,7 @@
                     ""Position"": ""(100.0, 4.0, -70.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Front"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -4930,7 +4930,7 @@
                     ""Position"": ""(38.0, 12.8, -29.8)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Front"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -4949,7 +4949,7 @@
                         {""Hyperdash"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Hyperdash"": 1, ""Swamp"": 1}
+                        {""Hyperdash"": 1, ""Swamp Front"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -4968,7 +4968,7 @@
                         {""Sword"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Front"": 1, ""Sword"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -4985,7 +4985,7 @@
                     ""Position"": ""(102.0, 6.0, -40.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Mid"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -5002,7 +5002,7 @@
                     ""Position"": ""(47.0, -1.0, 42.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Mid"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -5019,7 +5019,7 @@
                     ""Position"": ""(85.0, 0.0, 85.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Mid"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -5036,7 +5036,7 @@
                     ""Position"": ""(145.0, 4.0, 23.3)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Mid"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -5053,7 +5053,7 @@
                     ""Position"": ""(160.5, 4.0, -63.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Mid"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -5070,7 +5070,7 @@
                     ""Position"": ""(153.0, 16.0, -55.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Mid"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -5087,7 +5087,7 @@
                     ""Position"": ""(184.8, 15.0, 51.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Mid"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -5104,7 +5104,7 @@
                     ""Position"": ""(160.5, 12.0, 22.0)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Mid"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""
@@ -5140,7 +5140,7 @@
                     ""Position"": ""(75.0, 14.0, 172.6)"",
                     ""RequiredItems"": [],
                     ""RequiredItemsDoors"": [
-                        {""Swamp"": 1}
+                        {""Swamp Ledge under Cathedral Door"": 1}
                     ],
                     ""SceneId"": 59,
                     ""SceneName"": ""Swamp Redux 2""

--- a/src/Data/ItemListJson.cs
+++ b/src/Data/ItemListJson.cs
@@ -3571,7 +3571,7 @@
                         {""Lantern"": 1, ""Hyperdash"": 1}
                     ],
                     ""RequiredItemsDoors"": [
-                        {""Lantern"": 1, ""Beneath the Vault Front"": 1}
+                        {""Beneath the Vault Main"": 1}
                     ],
                     ""SceneId"": 14,
                     ""SceneName"": ""Fortress Basement""

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -16,7 +16,7 @@ namespace TunicRandomizer {
         public static Dictionary<string, int> SphereZero = new Dictionary<string, int>();
 
         // set this to true to test location access
-        public static bool testLocations = true;
+        public static bool testLocations = false;
         // leave this one alone
         public static bool testBool = false;
         
@@ -96,6 +96,9 @@ namespace TunicRandomizer {
             }
             if (SaveFile.GetInt(SaveFlags.LanternlessLogic) == 1) {
                 PrecollectedItems.Add("Lantern");
+            }
+            if (SaveFile.GetInt(SaveFlags.AbilityShuffle) == 0) {
+                PrecollectedItems.AddRange(new List<string> { "12", "21", "26" });
             }
 
 

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -23,6 +23,12 @@ namespace TunicRandomizer {
         // essentially fake items for the purpose of logic
         public static List<string> PrecollectedItems = new List<string>();
 
+        public static List<string> LadderItems = new List<string> { "Ladders near Weathervane", "Ladders near Overworld Checkpoint",
+            "Ladders near Patrol Cave", "Ladder near Temple Rafters", "Ladders near Dark Tomb", "Ladder to Quarry", "Ladders to West Bell",
+            "Ladders in Overworld Town", "Ladder to Ruined Atoll", "Ladder to Swamp", "Ladders in Well", "Ladder in Dark Tomb",
+            "Ladder to East Forest", "Ladders to Lower Forest", "Ladder to Beneath the Vault", "Ladders in Hourglass Cave",
+            "Ladders in South Atoll", "Ladders to Frog's Domain", "Ladders in Library", "Ladders in Lower Quarry", "Ladders in Swamp" };
+
         public static void PopulateSphereZero() {
             SphereZero.Clear();
             if (SaveFile.GetInt("randomizer shuffled abilities") == 0) {
@@ -74,17 +80,10 @@ namespace TunicRandomizer {
             Dictionary<string, int> SphereZeroInventory = new Dictionary<string, int>(SphereZero);
             Dictionary<string, Check> ProgressionLocations = new Dictionary<string, Check> { };
 
-
-            List<string> ladderItems = new List<string> { "Ladders near Weathervane", "Ladders near Overworld Checkpoint", "Ladders near Patrol Cave",
-                "Ladder near Temple Rafters", "Ladders near Dark Tomb", "Ladder to Quarry", "Ladders to West Bell", "Ladders in Overworld Town",
-                "Ladder to Ruined Atoll", "Ladder to Swamp", "Ladders in Well", "Ladder in Dark Tomb", "Ladder to East Forest",
-                "Ladders to Lower Forest", "Ladder to Beneath the Vault", "Ladders in Hourglass Cave", "Ladders in South Atoll",
-                "Ladders to Frog's Domain", "Ladders in Library", "Ladders in Lower Quarry", "Ladders in Swamp" };
-
             PrecollectedItems.Clear();
 
             // change this later to only add them if the ladder shuffle option is off
-            PrecollectedItems.AddRange(ladderItems);
+            PrecollectedItems.AddRange(LadderItems);
 
             if (SaveFile.GetInt(SaveFlags.MasklessLogic) == 1) {
                 PrecollectedItems.Add("Mask");
@@ -486,7 +485,7 @@ namespace TunicRandomizer {
         }
 
         // add a key if it doesn't exist, otherwise increment the value by 1
-        private static Dictionary<string, int> AddListToDict(Dictionary<string, int> dictionary, List<string> list) {
+        public static Dictionary<string, int> AddListToDict(Dictionary<string, int> dictionary, List<string> list) {
             foreach (string item in list) {
                 dictionary.TryGetValue(item, out var count);
                 dictionary[item] = count + 1;

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -16,7 +16,7 @@ namespace TunicRandomizer {
         public static Dictionary<string, int> SphereZero = new Dictionary<string, int>();
 
         // set this to true to test location access
-        public static bool testLocations = false;
+        public static bool testLocations = true;
         // leave this one alone
         public static bool testBool = false;
         
@@ -38,6 +38,12 @@ namespace TunicRandomizer {
             }
             if (SaveFile.GetInt("randomizer started with sword") == 1) {
                 SphereZero.Add("Sword", 1);
+            }
+            if (SaveFile.GetInt(SaveFlags.LanternlessLogic) == 1) {
+                SphereZero.Add("Lantern", 1);
+            }
+            if (SaveFile.GetInt(SaveFlags.MasklessLogic) == 1) {
+                SphereZero.Add("Mask", 1);
             }
         }
 

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -23,11 +23,7 @@ namespace TunicRandomizer {
         // essentially fake items for the purpose of logic
         public static List<string> PrecollectedItems = new List<string>();
 
-        public static List<string> LadderItems = new List<string> { "Ladders near Weathervane", "Ladders near Overworld Checkpoint",
-            "Ladders near Patrol Cave", "Ladder near Temple Rafters", "Ladders near Dark Tomb", "Ladder to Quarry", "Ladders to West Bell",
-            "Ladders in Overworld Town", "Ladder to Ruined Atoll", "Ladder to Swamp", "Ladders in Well", "Ladder in Dark Tomb",
-            "Ladder to East Forest", "Ladders to Lower Forest", "Ladder to Beneath the Vault", "Ladders in Hourglass Cave",
-            "Ladders in South Atoll", "Ladders to Frog's Domain", "Ladders in Library", "Ladders in Lower Quarry", "Ladders in Swamp" };
+        public static List<string> LadderItems = ItemLookup.Items.Where(item => item.Value.Type == ItemTypes.LADDER).Select(item => item.Value.Name).ToList();
 
         public static void PopulateSphereZero() {
             SphereZero.Clear();

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -115,20 +115,6 @@ namespace TunicRandomizer {
             }
             Shuffle(InitialItems, random);
             foreach (Check Item in InitialItems) {
-                
-                //if (SaveFile.GetInt(SaveFlags.MasklessLogic) == 1 || SaveFile.GetInt(SaveFlags.LanternlessLogic) == 1) {
-                //    if (Item.Location.RequiredItems.Count > 0 && Item.Location.RequiredItems.Where(dict => dict.ContainsKey("Mask") || dict.ContainsKey("Lantern")).Count() > 0) {
-                //        for (int i = 0; i < Item.Location.RequiredItems.Count; i++) {
-                //            if (Item.Location.RequiredItems[i].ContainsKey("Mask") && SaveFile.GetInt(SaveFlags.MasklessLogic) == 1) {
-                //                Item.Location.RequiredItems[i].Remove("Mask");
-                //            }
-                //            if (Item.Location.RequiredItems[i].ContainsKey("Lantern") && SaveFile.GetInt(SaveFlags.LanternlessLogic) == 1) {
-                //                Item.Location.RequiredItems[i].Remove("Lantern");
-                //            }
-                //        }
-                //    }
-                //}
-
                 if (SaveFile.GetInt("randomizer keys behind bosses") != 0 && (Item.Reward.Name.Contains("Hexagon") || Item.Reward.Name == "Vault Key (Red)")) {
                     if (Item.Reward.Name == "Hexagon Green" || Item.Reward.Name == "Hexagon Blue") {
                         Hexagons.Add(Item);

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -4823,6 +4823,33 @@ namespace TunicRandomizer {
                                     if (inventory.ContainsKey("Sword Progression")) {
                                         met_count++;
                                     }
+                                } else if (req == "12" && SaveFile.GetInt(SaveFlags.HexagonQuestEnabled) == 1 && SaveFile.GetInt(SaveFlags.AbilityShuffle) == 1) {
+                                    foreach (KeyValuePair<string, int> item in inventory) {
+                                        if (item.Key == "Hexagon Gold") {
+                                            if (item.Value >= SaveFile.GetInt($"randomizer hexagon quest prayer requirement")) {
+                                                met_count++;
+                                            }
+                                            break;
+                                        }
+                                    }
+                                } else if (req == "21" && SaveFile.GetInt(SaveFlags.HexagonQuestEnabled) == 1 && SaveFile.GetInt(SaveFlags.AbilityShuffle) == 1) {
+                                    foreach (KeyValuePair<string, int> item in inventory) {
+                                        if (item.Key == "Hexagon Gold") {
+                                            if (item.Value >= SaveFile.GetInt($"randomizer hexagon quest holy cross requirement")) {
+                                                met_count++;
+                                            }
+                                            break;
+                                        }
+                                    }
+                                } else if (req == "26" && SaveFile.GetInt(SaveFlags.HexagonQuestEnabled) == 1 && SaveFile.GetInt(SaveFlags.AbilityShuffle) == 1) {
+                                    foreach (KeyValuePair<string, int> item in inventory) {
+                                        if (item.Key == "Hexagon Gold") {
+                                            if (item.Value >= SaveFile.GetInt($"randomizer hexagon quest icebolt requirement")) {
+                                                met_count++;
+                                            }
+                                            break;
+                                        }
+                                    }
                                 } else if (inventory.ContainsKey(req)) {
                                     met_count++;
                                     //Logger.LogInfo("met_count is " + met_count);
@@ -5000,7 +5027,8 @@ namespace TunicRandomizer {
             string start_region = "Overworld";
 
             Dictionary<string, int> MaxItems = new Dictionary<string, int> {
-                { "Stick", 1 }, { "Sword", 1 }, { "Wand", 1 }, { "Stundagger", 1 }, { "Techbow", 1 }, { "Hyperdash", 1 }, { "Mask", 1 }, { "Lantern", 1 }, { "12", 1 }, { "21", 1 }, { "26", 1 }, { "Key", 2 }, { "Key (House)", 1 }
+                { "Stick", 1 }, { "Sword", 1 }, { "Wand", 1 }, { "Stundagger", 1 }, { "Techbow", 1 }, { "Hyperdash", 1 }, { "Mask", 1 },
+                { "Lantern", 1 }, { "12", 1 }, { "21", 1 }, { "26", 1 }, { "Key", 2 }, { "Key (House)", 1 }, { "Hexagon Gold", 50 }
             };
 
             Dictionary<string, int> FullInventory = new Dictionary<string, int>();

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -1295,7 +1295,27 @@ namespace TunicRandomizer {
                 new RegionInfo("Overworld Redux", false)
             },
             {
+                "Overworld Belltower at Bell",
+                new RegionInfo("Overworld Redux", false)
+            },
+            {
                 "Overworld Swamp Upper Entry",
+                new RegionInfo("Overworld Redux", false)
+            },
+            {
+                "Overworld Swamp Lower Entry",
+                new RegionInfo("Overworld Redux", false)
+            },
+            {
+                "After Ruined Passage",
+                new RegionInfo("Overworld Redux", false)
+            },
+            {
+                "Above Ruined Passage",
+                new RegionInfo("Overworld Redux", false)
+            },
+            {
+                "East Overworld",
                 new RegionInfo("Overworld Redux", false)
             },
             {
@@ -1303,13 +1323,61 @@ namespace TunicRandomizer {
                 new RegionInfo("Overworld Redux", false)
             },
             {
+                "Upper Overworld",
+                new RegionInfo("Overworld Redux", false)
+            },
+            {
+                "Overworld above Quarry Entrance",
+                new RegionInfo("Overworld Redux", false)
+            },
+            {
+                "Overworld after Temple Rafters",
+                new RegionInfo("Overworld Redux", false)
+            },
+            {
+                "Overworld Quarry Entry",
+                new RegionInfo("Overworld Redux", false)
+            },
+            {
+                "Overworld after Envoy",
+                new RegionInfo("Overworld Redux", false)
+            },
+            {
+                "Overworld at Patrol Cave",
+                new RegionInfo("Overworld Redux", false)
+            },
+            {
+                "Overworld above Patrol Cave",
+                new RegionInfo("Overworld Redux", false)
+            },
+            {
                 "Overworld West Garden Laurels Entry",
+                new RegionInfo("Overworld Redux", false)
+            },
+            {
+                "Overworld to West Garden Upper",
                 new RegionInfo("Overworld Redux", false)
             },
             {
                 "Overworld to West Garden from Furnace",
                 new RegionInfo("Overworld Redux", false)
             },
+            {
+                "Overworld Well Ladder",
+                new RegionInfo("Overworld Redux", false)
+            },
+            {
+                "Overworld Beach",
+                new RegionInfo("Overworld Redux", false)
+            },
+            {
+                "Overworld Tunnel Turret",
+                new RegionInfo("Overworld Redux", false)
+            },
+            {
+                "Overworld to Atoll Upper",
+                new RegionInfo("Overworld Redux", false)
+            }, 
             {
                 "Overworld Well to Furnace Rail",
                 new RegionInfo("Overworld Redux", false)
@@ -1423,6 +1491,10 @@ namespace TunicRandomizer {
                 new RegionInfo("Town Basement", true)
             },
             {
+                "Hourglass Cave Tower",
+                new RegionInfo("Town Basement", true)
+            },
+            {
                 "Sealed Temple",
                 new RegionInfo("Temple", false)
             },
@@ -1455,6 +1527,10 @@ namespace TunicRandomizer {
                 new RegionInfo("East Forest Redux", false)
             },
             {
+                "Lower Forest",
+                new RegionInfo("Town Basement", true)
+            },
+            {
                 "Guard House 1 East",
                 new RegionInfo("East Forest Redux Laddercave", false)
             },
@@ -1463,7 +1539,11 @@ namespace TunicRandomizer {
                 new RegionInfo("East Forest Redux Laddercave", false)
             },
             {
-                "Guard House 2",
+                "Guard House 2 Upper",
+                new RegionInfo("East Forest Redux Interior", false)
+            },
+            {
+                "Guard House 2 Lower",
                 new RegionInfo("East Forest Redux Interior", false)
             },
             {
@@ -1491,6 +1571,10 @@ namespace TunicRandomizer {
                 new RegionInfo("Crypt Redux", false)
             },
             {
+                "Dark Tomb Upper",
+                new RegionInfo("East Forest Redux Interior", false)
+            },
+            {
                 "Dark Tomb Main",
                 new RegionInfo("Crypt Redux", false)
             },
@@ -1505,6 +1589,10 @@ namespace TunicRandomizer {
             {
                 "Well Boss",
                 new RegionInfo("Sewer_Boss", false)
+            },
+            {
+                "Beneath the Well Ladder Exit",
+                new RegionInfo("Sewer", false)
             },
             {
                 "Beneath the Well Front",
@@ -1555,6 +1643,14 @@ namespace TunicRandomizer {
                 new RegionInfo("Atoll Redux", false)
             },
             {
+                "Ruined Atoll Ladder Tops",
+                new RegionInfo("Atoll Redux", false)
+            },
+            {
+                "Ruined Atoll Frog Eye",
+                new RegionInfo("Atoll Redux", false)
+            },
+            {
                 "Ruined Atoll Frog Mouth",
                 new RegionInfo("Atoll Redux", false)
             },
@@ -1567,8 +1663,24 @@ namespace TunicRandomizer {
                 new RegionInfo("Atoll Redux", false)
             },
             {
-                "Frog's Domain Entry",
+                "Frog Stairs Eye Exit",
                 new RegionInfo("Frog Stairs", false)
+            },
+            {
+                "Frog Stairs Upper",
+                new RegionInfo("Frog Stairs", false)
+            },
+            {
+                "Frog Stairs Lower",
+                new RegionInfo("Frog Stairs", false)
+            },
+            {
+                "Frog Stairs to Frog's Domain",
+                new RegionInfo("Frog Stairs", false)
+            },
+            {
+                "Frog's Domain Entry",
+                new RegionInfo("frog cave main", false)
             },
             {
                 "Frog's Domain",
@@ -1587,6 +1699,10 @@ namespace TunicRandomizer {
                 new RegionInfo("Library Exterior", false)
             },
             {
+                "Library Hall Bookshelf",
+                new RegionInfo("Library Hall", false)
+            },
+            {
                 "Library Hall",
                 new RegionInfo("Library Hall", false)
             },
@@ -1595,7 +1711,19 @@ namespace TunicRandomizer {
                 new RegionInfo("Library Hall", false)
             },
             {
+                "Library Hall to Rotunda",
+                new RegionInfo("Library Hall", false)
+            },
+            {
+                "Library Rotunda to Hall",
+                new RegionInfo("Library Rotunda", false)
+            },
+            {
                 "Library Rotunda",
+                new RegionInfo("Library Rotunda", false)
+            },
+            {
+                "Library Rotunda to Lab",
                 new RegionInfo("Library Rotunda", false)
             },
             {
@@ -1609,6 +1737,10 @@ namespace TunicRandomizer {
             {
                 "Library Portal",
                 new RegionInfo("Library Lab", false)
+            },
+            {
+                "Library Lab to Librarian",
+                new RegionInfo("Library Arena", true)
             },
             {
                 "Library Arena",
@@ -1627,12 +1759,20 @@ namespace TunicRandomizer {
                 new RegionInfo("Fortress Courtyard", false)
             },
             {
+                "Beneath the Vault Entry",
+                new RegionInfo("Fortress Courtyard", false)
+            },
+            {
                 "Fortress Courtyard",
                 new RegionInfo("Fortress Courtyard", false)
             },
             {
                 "Fortress Courtyard Upper",
                 new RegionInfo("Fortress Courtyard", false)
+            },
+            {
+                "Beneath the Vault Ladder Exit",
+                new RegionInfo("Fortress Basement", false)
             },
             {
                 "Beneath the Vault Front",
@@ -1743,6 +1883,10 @@ namespace TunicRandomizer {
                 new RegionInfo("Quarry Redux", false)
             },
             {
+                "Even Lower Quarry",
+                new RegionInfo("Quarry Redux", false)
+            },
+            {
                 "Lower Quarry Zig Door",
                 new RegionInfo("Quarry Redux", false)
             },
@@ -1795,7 +1939,15 @@ namespace TunicRandomizer {
                 new RegionInfo("ziggurat2020_FTRoom", false)
             },
             {
-                "Swamp",
+                "Swamp Front",
+                new RegionInfo("Swamp Redux 2", false)
+            },
+            {
+                "Swamp Mid",
+                new RegionInfo("Swamp Redux 2", false)
+            },
+            {
+                "Swamp Ledge under Cathedral Door",
                 new RegionInfo("Swamp Redux 2", false)
             },
             {
@@ -1941,13 +2093,32 @@ namespace TunicRandomizer {
                 "Overworld",
                 new Dictionary<string, List<List<string>>> {
                     {
-                        "Overworld Belltower",
+                        "Overworld Beach",
                         new List<List<string>> {
                             new List<string> {
                                 "Hyperdash",
                             },
                             new List<string> {
-                                "Ladder Storage",
+                                "Wand",
+                            },
+                            new List<string> {
+                                "Ladders in Overworld Town",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld to Atoll Upper",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld Belltower",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Hyperdash",
                             },
                         }
                     },
@@ -1957,8 +2128,13 @@ namespace TunicRandomizer {
                             new List<string> {
                                 "Hyperdash",
                             },
+                        }
+                    },
+                    {
+                        "Overworld Swamp Lower Entry",
+                        new List<List<string>> {
                             new List<string> {
-                                "Ladder Storage",
+                                "Ladder to Swamp",
                             },
                         }
                     },
@@ -1968,19 +2144,89 @@ namespace TunicRandomizer {
                             new List<string> {
                                 "Hyperdash",
                             },
+                        }
+                    },
+                    {
+                        "Overworld Well Ladder",
+                        new List<List<string>> {
                             new List<string> {
-                                "Ladder Storage",
+                                "Ladders in Well",
                             },
                         }
                     },
                     {
-                        "Overworld West Garden Laurels Entry",
+                        "Overworld Ruined Passage Door",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Key",
+                            },
+                        }
+                    },
+                    {
+                        "After Ruined Passage",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Weathervane",
+                            },
+                        }
+                    },
+                    {
+                        "Above Ruined Passage",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Weathervane",
+                            },
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                        }
+                    },
+                    {
+                        "East Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Overworld Checkpoint",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld above Patrol Cave",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Overworld Checkpoint",
+                            },
+                            new List<string> {
+                                "Wand",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld above Quarry Entrance",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Dark Tomb",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld after Envoy",
                         new List<List<string>> {
                             new List<string> {
                                 "Hyperdash",
                             },
                             new List<string> {
-                                "Ladder Storage",
+                                "Wand",
+                            },
+                            new List<string> {  // todo: make this work
+                                "Heir Sword",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld Tunnel Turret",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Hyperdash",
                             },
                         }
                     },
@@ -1993,30 +2239,13 @@ namespace TunicRandomizer {
                         }
                     },
                     {
-                        "Overworld Ruined Passage Door",
-                        new List<List<string>> {
-                            new List<string> {
-                                "Key",
-                            },
-                            new List<string> {
-                                "Hyperdash", "nmg",
-                            },
-                        }
-                    },
-                    {
                         "Overworld Temple Door",
                         new List<List<string>> {
                             new List<string> {
-                                "26", "Techbow", "Wand", "Stundagger", "nmg",
+                                "Stick", "Forest Belltower Upper", "Overworld Belltower at Bell",
                             },
                             new List<string> {
-                                "Techbow", "Forest Belltower Upper", "nmg",
-                            },
-                            new List<string> {
-                                "Stick", "Forest Belltower Upper", "Overworld Belltower",
-                            },
-                            new List<string> {
-                                "Techbow", "Forest Belltower Upper", "Overworld Belltower",
+                                "Techbow", "Forest Belltower Upper", "Overworld Belltower at Bell",
                             },
                         }
                     },
@@ -2048,21 +2277,311 @@ namespace TunicRandomizer {
                         }
                     },
                     {
-                        "Overworld Well to Furnace Rail",
-                        new List<List<string>> {
-                            new List<string> {
-                                "Ladder Storage",
-                            },
-                        }
-                    },
-                    {
                         "Overworld Old House Door",
                         new List<List<string>> {
                             new List<string> {
                                 "Key (House)",
                             },
+                        }
+                    },
+                }
+            },
+            {
+                "East Overworld",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Above Ruined Passage",
+                        new List<List<string>> {
                             new List<string> {
-                                "Stundagger", "Wand", "nmg",
+                                "Ladders near Weathervane",
+                            },
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Overworld Checkpoint",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld at Patrol Cave",
+                        new List<List<string>> {
+                        }
+                    },
+                    {
+                        "Overworld above Patrol Cave",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Overworld Checkpoint",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld Special Shop Entry",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Overworld Special Shop Entry",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "East Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Overworld Belltower",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Overworld Belltower at Bell",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders to West Bell",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld",
+                        new List<List<string>> {
+                        }
+                    },
+                    {
+                        "Overworld to West Garden Upper",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders to West Bell",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Overworld to West Garden Upper",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Overworld Belltower",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders to West Bell",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Overworld Swamp Upper Entry",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Overworld Swamp Lower Entry",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladder to Swamp",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Overworld Beach",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                            new List<string> {
+                                "Wand",
+                            },
+                            new List<string> {
+                                "Ladders in Overworld Town",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld West Garden Laurels Entry",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld to Atoll Upper",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladder to Ruined Atoll",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld Tunnel Turret",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Overworld Town",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Overworld West Garden Laurels Entry",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Overworld Beach",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Overworld to Atoll Upper",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                            new List<string> {
+                                "Wand",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld Beach",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladder to Ruined Atoll",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Overworld Tunnel Turret",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                            new List<string> {
+                                "Wand",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld Beach",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Overworld Town",
+                            },
+                            new List<string> {
+                                "Wand",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Overworld Well Ladder",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Well",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Overworld at Patrol Cave",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "East Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld above Patrol Cave",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Patrol Cave",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Overworld above Patrol Cave",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Overworld Checkpoint",
+                            },
+                        }
+                    },
+                    {
+                        "East Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Overworld Checkpoint",
+                            },
+                        }
+                    },
+                    {
+                        "Upper Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Patrol Cave",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld at Patrol Cave",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Patrol Cave",
                             },
                         }
                     },

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -2852,24 +2852,13 @@ namespace TunicRandomizer {
                 }
             },
             {
-                "East Forest",
+                "Hourglass Cave",
                 new Dictionary<string, List<List<string>>> {
                     {
-                        "East Forest Dance Fox Spot",
+                        "Hourglass Cave Tower",
                         new List<List<string>> {
                             new List<string> {
-                                "Hyperdash",
-                            },
-                            new List<string> {
-                                "26", "nmg",
-                            },
-                        }
-                    },
-                    {
-                        "East Forest Portal",
-                        new List<List<string>> {
-                            new List<string> {
-                                "12",
+                                "Ladders in Hourglass Cave",
                             },
                         }
                     },
@@ -2891,6 +2880,41 @@ namespace TunicRandomizer {
                         {
                         "Forest Belltower Lower",
                         new List<List<string>> {
+                            new List<string> {
+                                "Ladder to East Forest",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "East Forest",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "East Forest Dance Fox Spot",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                        }
+                    },
+                    {
+                        "East Forest Portal",
+                        new List<List<string>> {
+                            new List<string> {
+                                "12",
+                            },
+                        }
+                    },
+                    {
+                        "Lower Forest",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders to Lower Forest",
+                            },
+                            new List<string> {
+                                "26", "Wand", "Techbow", "Stundagger"
+                            },
                         }
                     },
                 }
@@ -2904,9 +2928,6 @@ namespace TunicRandomizer {
                             new List<string> {
                                 "Hyperdash",
                             },
-                            new List<string> {
-                                "26", "nmg",
-                            },
                         }
                     },
                 }
@@ -2917,6 +2938,19 @@ namespace TunicRandomizer {
                     {
                         "East Forest",
                         new List<List<string>> {
+                        }
+                    },
+                }
+            },
+            {
+                "Lower Forest",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "East Forest",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders to Lower Forest",
+                            },
                         }
                     },
                 }
@@ -2939,6 +2973,32 @@ namespace TunicRandomizer {
                         new List<List<string>> {
                             new List<string> {
                                 "Hyperdash",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Guard House 2 Upper",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Guard House 2 Lower",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders to Lower Forest",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Guard House 2 Lower",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Guard House 2 Upper",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders to Lower Forest",
                             },
                         }
                     },
@@ -2971,9 +3031,6 @@ namespace TunicRandomizer {
                             new List<string> {
                                 "Hyperdash",
                             },
-                            new List<string> {
-                                "26", "nmg",
-                            },
                         }
                     },
                 }
@@ -2986,14 +3043,6 @@ namespace TunicRandomizer {
                         new List<List<string>> {
                             new List<string> {
                                 "12",
-                            },
-                        }
-                    },
-                    {
-                        "Forest Grave Path Main",
-                        new List<List<string>> {
-                            new List<string> {
-                                "Hyperdash", "nmg",
                             },
                         }
                     },
@@ -3010,8 +3059,29 @@ namespace TunicRandomizer {
                 }
             },
             {
+                "Beneath the Well Ladder Exit",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Beneath the Well Front",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Well",
+                            },
+                        }
+                    },
+                }
+            },
+            {
                 "Beneath the Well Front",
                 new Dictionary<string, List<List<string>>> {
+                    {
+                        "Beneath the Well Ladder Exit",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Well",
+                            },
+                        }
+                    },
                     {
                         "Beneath the Well Main",
                         new List<List<string>> {
@@ -3020,22 +3090,6 @@ namespace TunicRandomizer {
                             },
                             new List<string> {
                                 "Techbow", "Lantern"
-                            },
-                        }
-                    },
-                }
-            },
-            {
-                "Beneath the Well Back",
-                new Dictionary<string, List<List<string>>> {
-                    {
-                        "Beneath the Well Main",
-                        new List<List<string>> {
-                            new List<string> {
-                                "Stick"
-                            },
-                            new List<string> {
-                                "Techbow"
                             },
                         }
                     },
@@ -3052,6 +3106,25 @@ namespace TunicRandomizer {
                     {
                         "Beneath the Well Back",
                         new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Well",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Beneath the Well Back",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Beneath the Well Main",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Stick", "Ladders in Well"
+                            },
+                            new List<string> {
+                                "Techbow", "Ladders in Well"
+                            },
                         }
                     },
                 }
@@ -3067,26 +3140,31 @@ namespace TunicRandomizer {
                 }
             },
             {
-                "Dark Tomb Checkpoint",
+                "Dark Tomb Entry Point",
                 new Dictionary<string, List<List<string>>> {
                     {
-                        "Well Boss",
+                        "Dark Tomb Upper",
                         new List<List<string>> {
                             new List<string> {
-                                "Hyperdash", "nmg",
+                                "Lantern"
                             },
                         }
                     },
                 }
             },
             {
-                "Dark Tomb Entry Point",
+                "Dark Tomb Upper",
                 new Dictionary<string, List<List<string>>> {
+                    {
+                        "Dark Tomb Entry Point",
+                        new List<List<string>> {
+                        }
+                    },
                     {
                         "Dark Tomb Main",
                         new List<List<string>> {
                             new List<string> {
-                                "Lantern"
+                                "Ladder in Dark Tomb"
                             },
                         }
                     },
@@ -3101,8 +3179,11 @@ namespace TunicRandomizer {
                         }
                     },
                     {
-                        "Dark Tomb Entry Point",
+                        "Dark Tomb Upper",
                         new List<List<string>> {
+                            new List<string> {
+                                "Ladder in Dark Tomb"
+                            },
                         }
                     },
                 }

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -3274,14 +3274,6 @@ namespace TunicRandomizer {
                 "West Garden Portal Item",
                 new Dictionary<string, List<List<string>>> {
                     {
-                        "West Garden",
-                        new List<List<string>> {
-                            new List<string> {
-                                "26", "Wand", "Stundagger", "Techbow", "nmg"
-                            },
-                        }
-                    },
-                    {
                         "West Garden Portal",
                         new List<List<string>> {
                             new List<string> {
@@ -3323,8 +3315,13 @@ namespace TunicRandomizer {
                             new List<string> {
                                 "Hyperdash",
                             },
+                        }
+                    },
+                    {
+                        "Ruined Atoll Ladder Tops",
+                        new List<List<string>> {
                             new List<string> {
-                                "Ladder Storage",
+                                "Ladders in South Atoll",
                             },
                         }
                     },
@@ -3337,8 +3334,13 @@ namespace TunicRandomizer {
                             new List<string> {
                                 "Wand",
                             },
+                        }
+                    },
+                    {
+                        "Ruined Atoll Frog Eye",
+                        new List<List<string>> {
                             new List<string> {
-                                "Ladder Storage",
+                                "Ladders to Frog's Domain",
                             },
                         }
                     },
@@ -3354,7 +3356,7 @@ namespace TunicRandomizer {
                         "Ruined Atoll Statue",
                         new List<List<string>> {
                             new List<string> {
-                                "12",
+                                "12", "Ladders in South Atoll"
                             },
                         }
                     },
@@ -3412,9 +3414,100 @@ namespace TunicRandomizer {
                     },
                 }
             },
+
+            {
+                "Frog Stairs Eye Exit",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Frog Stairs Upper",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders to Frog's Domain",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Frog Stairs Upper",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Frog Stairs Eye Exit",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders to Frog's Domain",
+                            },
+                        }
+                    },
+                    {
+                        "Frog Stairs Lower",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders to Frog's Domain",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Frog Stairs Lower",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Frog Stairs Upper",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders to Frog's Domain",
+                            },
+                        }
+                    },
+                    {
+                        "Frog Stairs to Frog's Domain",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders to Frog's Domain",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Frog Stairs to Frog's Domain",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Frog Stairs Lower",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders to Frog's Domain",
+                            },
+                        }
+                    },
+                }
+            },
+
+            {
+                "Frog's Domain Entry",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Frog's Domain",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders to Frog's Domain",
+                            },
+                        }
+                    },
+                }
+            },
             {
                 "Frog's Domain",
                 new Dictionary<string, List<List<string>>> {
+                    {
+                        "Frog's Domain Entry",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders to Frog's Domain",
+                            },
+                        }
+                    },
                     {
                         "Frog's Domain Back",
                         new List<List<string>> {
@@ -3432,7 +3525,7 @@ namespace TunicRandomizer {
                         "Library Exterior Tree",
                         new List<List<string>> {
                             new List<string> {
-                                "Hyperdash", "12",
+                                "Hyperdash", "12", "Ladders in Library",
                             },
                             new List<string> {
                                 "Wand", "12",
@@ -3448,10 +3541,23 @@ namespace TunicRandomizer {
                         "Library Exterior Ladder",
                         new List<List<string>> {
                             new List<string> {
-                                "Hyperdash",
+                                "Hyperdash", "Ladders in Library",
                             },
                             new List<string> {
-                                "Wand",
+                                "Wand", "Ladders in Library",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Library Hall Bookshelf",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Library Hall",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Library",
                             },
                         }
                     },
@@ -3461,10 +3567,26 @@ namespace TunicRandomizer {
                 "Library Hall",
                 new Dictionary<string, List<List<string>>> {
                     {
+                        "Library Hall Bookshelf",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Library",
+                            },
+                        }
+                    },
+                    {
                         "Library Hero's Grave",
                         new List<List<string>> {
                             new List<string> {
                                 "12",
+                            },
+                        }
+                    },
+                    {
+                        "Library Hall to Rotunda",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Library",
                             },
                         }
                     },
@@ -3481,16 +3603,76 @@ namespace TunicRandomizer {
                 }
             },
             {
+                "Library Hall to Rotunda",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Library Hall",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Library",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Library Rotunda to Hall",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Library Rotunda",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Library",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Library Rotunda",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Library Rotunda to Hall",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Library",
+                            },
+                        }
+                    },
+                    {
+                        "Library Rotunda to Lab",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Library",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Library Rotunda to Lab",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Library Rotunda",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Library",
+                            },
+                        }
+                    },
+                }
+            },
+            {
                 "Library Lab Lower",
                 new Dictionary<string, List<List<string>>> {
                     {
                         "Library Lab",
                         new List<List<string>> {
                             new List<string> {
-                                "Hyperdash",
+                                "Hyperdash", "Ladders in Library",
                             },
                             new List<string> {
-                                "Wand",
+                                "Wand", "Ladders in Library",
                             },
                         }
                     },
@@ -3503,7 +3685,7 @@ namespace TunicRandomizer {
                         "Library Lab Lower",
                         new List<List<string>> {
                             new List<string> {
-                                "Hyperdash",
+                                "Hyperdash", "Ladders in Library",
                             },
                         }
                     },
@@ -3515,6 +3697,14 @@ namespace TunicRandomizer {
                             },
                         }
                     },
+                    {
+                        "Library Lab to Librarian",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Library",
+                            },
+                        }
+                    },
                 }
             },
             {
@@ -3523,6 +3713,19 @@ namespace TunicRandomizer {
                     {
                         "Library Lab",
                         new List<List<string>> {
+                        }
+                    },
+                }
+            },
+            {
+                "Library Lab to Librarian",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Library Lab",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Library",
+                            },
                         }
                     },
                 }

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -40,28 +40,70 @@ namespace TunicRandomizer {
                         new List<TunicPortal> {
                             new TunicPortal("Stick House Entrance", "Sword Cave", "_"),
                             new TunicPortal("Windmill Entrance", "Windmill", "_"),
-                            new TunicPortal("Well Ladder Entrance", "Sewer", "_entrance"),
                             new TunicPortal("Old House Waterfall Entrance", "Overworld Interiors", "_under_checkpoint"),
                             new TunicPortal("Entrance to Furnace under Windmill", "Furnace", "_gyro_upper_east"),
-                            new TunicPortal("Entrance to Furnace from Beach", "Furnace", "_gyro_lower"),
-                            new TunicPortal("Caustic Light Cave Entrance", "Overworld Cave", "_"),
-                            new TunicPortal("Swamp Lower Entrance", "Swamp Redux 2", "_conduit"),
-                            new TunicPortal("Ruined Passage Not-Door Entrance", "Ruins Passage", "_east"),
-                            new TunicPortal("Atoll Upper Entrance", "Atoll Redux", "_upper"),
-                            new TunicPortal("Atoll Lower Entrance", "Atoll Redux", "_lower"),
-                            new TunicPortal("Maze Cave Entrance", "Maze Room", "_"),
-                            new TunicPortal("Temple Rafters Entrance", "Temple", "_rafters"),
                             new TunicPortal("Ruined Shop Entrance", "Ruined Shop", "_"),
-                            new TunicPortal("Patrol Cave Entrance", "PatrolCave", "_"),
-                            new TunicPortal("Hourglass Cave Entrance", "Town Basement", "_beach"),
                             new TunicPortal("Changing Room Entrance", "Changing Room", "_"),
                             new TunicPortal("Cube Cave Entrance", "CubeRoom", "_"),
-                            new TunicPortal("Stairs from Overworld to Mountain", "Mountain", "_"),
-                            new TunicPortal("Overworld to Fortress", "Fortress Courtyard", "_"),
-                            new TunicPortal("Overworld to Quarry Connector", "Darkwoods Tunnel", "_"),
                             new TunicPortal("Dark Tomb Main Entrance", "Crypt Redux", "_"),
-                            new TunicPortal("Overworld to Forest Belltower", "Forest Belltower", "_"),
                             new TunicPortal("Secret Gathering Place Entrance", "Waterfall", "_"),
+                        }
+                    },
+                    {
+                        "East Overworld",
+                        new List<TunicPortal> {
+                            new TunicPortal("Overworld to Forest Belltower", "Forest Belltower", "_"),
+                            new TunicPortal("Overworld to Fortress", "Fortress Courtyard", "_"),
+                        }
+                    },
+                    {
+                        "Overworld at Patrol Cave",
+                        new List<TunicPortal> {
+                            new TunicPortal("Patrol Cave Entrance", "PatrolCave", "_"),
+                        }
+                    },
+                    {
+                        "Upper Overworld",
+                        new List<TunicPortal> {
+                            new TunicPortal("Stairs from Overworld to Mountain", "Mountain", "_"),
+                        }
+                    },
+                    {
+                        "Overworld after Temple Rafters",
+                        new List<TunicPortal> {
+                            new TunicPortal("Temple Rafters Entrance", "Temple", "_rafters"),
+                        }
+                    },
+                    {
+                        "Overworld Quarry Entry",
+                        new List<TunicPortal> {
+                            new TunicPortal("Overworld to Quarry Connector", "Darkwoods Tunnel", "_"),
+                        }
+                    },
+                    {
+                        "Overworld Beach",
+                        new List<TunicPortal> {
+                            new TunicPortal("Atoll Lower Entrance", "Atoll Redux", "_lower"),
+                            new TunicPortal("Hourglass Cave Entrance", "Town Basement", "_beach"),
+                            new TunicPortal("Maze Cave Entrance", "Maze Room", "_"),
+                        }
+                    },
+                    {
+                        "Overworld Tunnel Turret",
+                        new List<TunicPortal> {
+                            new TunicPortal("Entrance to Furnace from Beach", "Furnace", "_gyro_lower"),
+                        }
+                    },
+                    {
+                        "Overworld to Atoll Upper",
+                        new List<TunicPortal> {
+                            new TunicPortal("Atoll Upper Entrance", "Atoll Redux", "_upper"),
+                        }
+                    },
+                    {
+                        "Overworld Well Ladder",
+                        new List<TunicPortal> {
+                            new TunicPortal("Well Ladder Entrance", "Sewer", "_entrance"),
                         }
                     },
                     {
@@ -78,10 +120,23 @@ namespace TunicRandomizer {
                         }
                     },
                     {
+                        "Overworld to West Garden Upper",
+                        new List<TunicPortal> {
+                            new TunicPortal("West Garden Entrance near Belltower", "Archipelagos Redux", "_upper"),
+                        }
+                    },
+                    {
                         "Overworld to West Garden from Furnace",
                         new List<TunicPortal> {
                             new TunicPortal("Entrance to Furnace near West Garden", "Furnace", "_gyro_west"),
                             new TunicPortal("West Garden Entrance from Furnace", "Archipelagos Redux", "_lower"),
+                        }
+                    },
+                    {
+                        "Overworld Swamp Lower Entry",
+                        new List<TunicPortal> {
+                            new TunicPortal("Caustic Light Cave Entrance", "Overworld Cave", "_"),
+                            new TunicPortal("Swamp Lower Entrance", "Swamp Redux 2", "_conduit"),
                         }
                     },
                     {
@@ -97,15 +152,15 @@ namespace TunicRandomizer {
                         }
                     },
                     {
-                        "Overworld Special Shop Entry",
+                        "After Ruined Passage",
                         new List<TunicPortal> {
-                            new TunicPortal("Special Shop Entrance", "ShopSpecial", "_"),
+                            new TunicPortal("Ruined Passage Not-Door Entrance", "Ruins Passage", "_east"),
                         }
                     },
                     {
-                        "Overworld Belltower",
+                        "Overworld Special Shop Entry",
                         new List<TunicPortal> {
-                            new TunicPortal("West Garden Entrance near Belltower", "Archipelagos Redux", "_upper"),
+                            new TunicPortal("Special Shop Entrance", "ShopSpecial", "_"),
                         }
                     },
                     {
@@ -377,7 +432,7 @@ namespace TunicRandomizer {
                 "Sewer",
                 new Dictionary<string, List<TunicPortal>> {
                     {
-                        "Beneath the Well Front",
+                        "Beneath the Well Ladder Exit",
                         new List<TunicPortal> {
                             new TunicPortal("Well Ladder Exit", "Overworld Redux", "_entrance"),
                         }
@@ -482,7 +537,6 @@ namespace TunicRandomizer {
                         new List<TunicPortal> {
                             new TunicPortal("Atoll Upper Exit", "Overworld Redux", "_upper"),
                             new TunicPortal("Atoll Shop", "Shop", "_"),
-                            new TunicPortal("Frog Stairs Eye Entrance", "Frog Stairs", "_eye"),
                         }
                     },
                     {
@@ -504,6 +558,12 @@ namespace TunicRandomizer {
                         }
                     },
                     {
+                        "Ruined Atoll Frog Eye",
+                        new List<TunicPortal> {
+                            new TunicPortal("Frog Stairs Eye Entrance", "Frog Stairs", "_eye"),
+                        }
+                    },
+                    {
                         "Ruined Atoll Frog Mouth",
                         new List<TunicPortal> {
                             new TunicPortal("Frog Stairs Mouth Entrance", "Frog Stairs", "_mouth"),
@@ -515,12 +575,27 @@ namespace TunicRandomizer {
                 "Frog Stairs",
                 new Dictionary<string, List<TunicPortal>> {
                     {
-                        "Frog's Domain Entry",
+                        "Frog Stairs Eye Exit",
                         new List<TunicPortal> {
                             new TunicPortal("Frog Stairs Eye Exit", "Atoll Redux", "_eye"),
+                        }
+                    },
+                    {
+                        "Frog Stairs Upper",
+                        new List<TunicPortal> {
                             new TunicPortal("Frog Stairs Mouth Exit", "Atoll Redux", "_mouth"),
-                            new TunicPortal("Frog Stairs to Frog's Domain's Entrance", "frog cave main", "_Entrance"),
+                        }
+                    },
+                    {
+                        "Frog Stairs Lower",
+                        new List<TunicPortal> {
                             new TunicPortal("Frog Stairs to Frog's Domain's Exit", "frog cave main", "_Exit"),
+                        }
+                    },
+                    {
+                        "Frog Stairs to Frog's Domain",
+                        new List<TunicPortal> {
+                            new TunicPortal("Frog Stairs to Frog's Domain's Entrance", "frog cave main", "_Entrance"),
                         }
                     },
                 }
@@ -529,7 +604,7 @@ namespace TunicRandomizer {
                 "frog cave main",
                 new Dictionary<string, List<TunicPortal>> {
                     {
-                        "Frog's Domain",
+                        "Frog's Domain Entry",
                         new List<TunicPortal> {
                             new TunicPortal("Frog's Domain Ladder Exit", "Frog Stairs", "_Entrance"),
                         }
@@ -563,10 +638,9 @@ namespace TunicRandomizer {
                 "Library Hall",
                 new Dictionary<string, List<TunicPortal>> {
                     {
-                        "Library Hall",
+                        "Library Hall Bookshelf",
                         new List<TunicPortal> {
                             new TunicPortal("Library Hall Bookshelf Exit", "Library Exterior", "_"),
-                            new TunicPortal("Library Hall to Rotunda", "Library Rotunda", "_"),
                         }
                     },
                     {
@@ -575,15 +649,26 @@ namespace TunicRandomizer {
                             new TunicPortal("Library Hero's Grave", "RelicVoid", "_teleporter_relic plinth"),
                         }
                     },
+                    {
+                        "Library Hall to Rotunda",
+                        new List<TunicPortal> {
+                            new TunicPortal("Library Hall to Rotunda", "Library Rotunda", "_"),
+                        }
+                    },
                 }
             },
             {
                 "Library Rotunda",
                 new Dictionary<string, List<TunicPortal>> {
                     {
-                        "Library Rotunda",
+                        "Library Rotunda to Hall",
                         new List<TunicPortal> {
                             new TunicPortal("Library Rotunda Lower Exit", "Library Hall", "_"),
+                        }
+                    },
+                    {
+                        "Library Rotunda to Lab",
+                        new List<TunicPortal> {
                             new TunicPortal("Library Rotunda Upper Exit", "Library Lab", "_"),
                         }
                     },
@@ -605,7 +690,7 @@ namespace TunicRandomizer {
                         }
                     },
                     {
-                        "Library Lab",
+                        "Library Lab to Librarian",
                         new List<TunicPortal> {
                             new TunicPortal("Library Lab to Librarian Arena", "Library Arena", "_"),
                         }
@@ -632,7 +717,6 @@ namespace TunicRandomizer {
                             new TunicPortal("Forest to Belltower", "Forest Belltower", "_"),
                             new TunicPortal("Forest Guard House 1 Lower Entrance", "East Forest Redux Laddercave", "_lower"),
                             new TunicPortal("Forest Guard House 1 Gate Entrance", "East Forest Redux Laddercave", "_gate"),
-                            new TunicPortal("Forest Guard House 2 Lower Entrance", "East Forest Redux Interior", "_lower"),
                             new TunicPortal("Forest Guard House 2 Upper Entrance", "East Forest Redux Interior", "_upper"),
                             new TunicPortal("Forest Grave Path Lower Entrance", "Sword Access", "_lower"),
                             new TunicPortal("Forest Grave Path Upper Entrance", "Sword Access", "_upper"),
@@ -648,6 +732,12 @@ namespace TunicRandomizer {
                         "East Forest Portal",
                         new List<TunicPortal> {
                             new TunicPortal("Forest to Far Shore", "Transit", "_teleporter_forest teleporter"),
+                        }
+                    },
+                    {
+                        "Lower Forest",
+                        new List<TunicPortal> {
+                            new TunicPortal("Forest Guard House 2 Lower Entrance", "East Forest Redux Interior", "_lower"),
                         }
                     },
                 }
@@ -698,10 +788,15 @@ namespace TunicRandomizer {
                 "East Forest Redux Interior",
                 new Dictionary<string, List<TunicPortal>> {
                     {
-                        "Guard House 2",
+                        "Guard House 2 Upper",
+                        new List<TunicPortal> {
+                            new TunicPortal("Guard House 2 Upper Exit", "East Forest Redux", "_upper"),
+                        }
+                    },
+                    {
+                        "Guard House 2 Lower",
                         new List<TunicPortal> {
                             new TunicPortal("Guard House 2 Lower Exit", "East Forest Redux", "_lower"),
-                            new TunicPortal("Guard House 2 Upper Exit", "East Forest Redux", "_upper"),
                         }
                     },
                 }
@@ -762,8 +857,13 @@ namespace TunicRandomizer {
                     {
                         "Fortress Exterior near cave",
                         new List<TunicPortal> {
-                            new TunicPortal("Fortress Courtyard to Beneath the Earth", "Fortress Basement", "_"),
                             new TunicPortal("Fortress Courtyard Shop", "Shop", "_"),
+                        }
+                    },
+                    {
+                        "Beneath the Vault Entry",
+                        new List<TunicPortal> {
+                            new TunicPortal("Fortress Courtyard to Beneath the Earth", "Fortress Basement", "_"),
                         }
                     },
                     {
@@ -1084,7 +1184,7 @@ namespace TunicRandomizer {
                 "Swamp Redux 2",
                 new Dictionary<string, List<TunicPortal>> {
                     {
-                        "Swamp",
+                        "Swamp Front",
                         new List<TunicPortal> {
                             new TunicPortal("Swamp Lower Exit", "Overworld Redux", "_conduit"),
                             new TunicPortal("Swamp Shop", "Shop", "_"),

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -790,7 +790,7 @@ namespace TunicRandomizer {
                         }
                     },
                     {
-                        "Beneath the Vault Front",
+                        "Beneath the Vault Ladder Exit",
                         new List<TunicPortal> {
                             new TunicPortal("Beneath the Earth to Fortress Courtyard", "Fortress Courtyard", "_"),
                         }
@@ -1775,7 +1775,7 @@ namespace TunicRandomizer {
                 new RegionInfo("Fortress Basement", false)
             },
             {
-                "Beneath the Vault Front",
+                "Beneath the Vault Main",
                 new RegionInfo("Fortress Basement", false)
             },
             {
@@ -3742,33 +3742,6 @@ namespace TunicRandomizer {
                             new List<string> {
                                 "Wand",
                             },
-                            new List<string> {
-                                "Ladder Storage",
-                            },
-                        }
-                    },
-                    {
-                        "Fortress Courtyard Upper",
-                        new List<List<string>> {
-                            new List<string> {
-                                "Ladder Storage",
-                            },
-                        }
-                    },
-                    {
-                        "Fortress Exterior near cave",
-                        new List<List<string>> {
-                            new List<string> {
-                                "Ladder Storage",
-                            },
-                        }
-                    },
-                    {
-                        "Fortress Courtyard",
-                        new List<List<string>> {
-                            new List<string> {
-                                "Ladder Storage",
-                            },
                         }
                     },
                 }
@@ -3793,9 +3766,6 @@ namespace TunicRandomizer {
                             new List<string> {
                                 "Hyperdash",
                             },
-                            new List<string> {
-                                "Ladder Storage",
-                            },
                         }
                     },
                     {
@@ -3803,12 +3773,6 @@ namespace TunicRandomizer {
                         new List<List<string>> {
                             new List<string> {
                                 "Hyperdash",
-                            },
-                            new List<string> {
-                                "26", "Techbow", "Wand", "Stundagger", "nmg",
-                            },
-                            new List<string> {
-                                "Ladder Storage",
                             },
                         }
                     },
@@ -3823,24 +3787,26 @@ namespace TunicRandomizer {
                             new List<string> {
                                 "Hyperdash",
                             },
-                            new List<string> {
-                                "Ladder Storage",
-                            },
                         }
                     },
                     {
-                        "Fortress Courtyard",
+                        "Beneath the Vault Entry",
                         new List<List<string>> {
                             new List<string> {
-                                "Ladder Storage",
+                                "Ladder to Beneath the Vault",
                             },
                         }
                     },
+                }
+            },
+            {
+                "Beneath the Vault Entry",
+                new Dictionary<string, List<List<string>>> {
                     {
-                        "Fortress Courtyard Upper",
+                        "Fortress Exterior near cave",
                         new List<List<string>> {
                             new List<string> {
-                                "Ladder Storage",
+                                "Ladder to Beneath the Vault",
                             },
                         }
                     },
@@ -3849,14 +3815,6 @@ namespace TunicRandomizer {
             {
                 "Fortress Courtyard",
                 new Dictionary<string, List<List<string>>> {
-                    {
-                        "Fortress Courtyard Upper",
-                        new List<List<string>> {
-                            new List<string> {
-                                "26", "Techbow", "Wand", "Stundagger", "nmg",
-                            },
-                        }
-                    },
                     {
                         "Fortress Exterior from Overworld",
                         new List<List<string>> {
@@ -3878,14 +3836,32 @@ namespace TunicRandomizer {
                 }
             },
             {
-                "Beneath the Vault Front",
+                "Beneath the Vault Ladder Exit",
                 new Dictionary<string, List<List<string>>> {
+                    {
+                        "Beneath the Vault Main",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Lantern", "Ladder to Beneath the Vault",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Beneath the Vault Main",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Beneath the Vault Ladder Exit",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladder to Beneath the Vault",
+                            },
+                        }
+                    },
                     {
                         "Beneath the Vault Back",
                         new List<List<string>> {
-                            new List<string> {
-                                "Lantern",
-                            },
                         }
                     },
                 }
@@ -3894,20 +3870,18 @@ namespace TunicRandomizer {
                 "Beneath the Vault Back",
                 new Dictionary<string, List<List<string>>> {
                     {
-                        "Beneath the Vault Front",
-                        new List<List<string>> {
-                        }
-                    },
-                }
-            },
-            {
-                "Fortress East Shortcut Lower",
-                new Dictionary<string, List<List<string>>> {
-                    {
-                        "Fortress East Shortcut Upper",
+                        "Beneath the Vault Main",
                         new List<List<string>> {
                             new List<string> {
-                                "26", "Techbow", "Wand", "Stundagger", "nmg",
+                                "Lantern",
+                            },
+                        }
+                    },
+                    {
+                        "Beneath the Vault Ladder Exit",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladder to Beneath the Vault",
                             },
                         }
                     },

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -2588,6 +2588,171 @@ namespace TunicRandomizer {
                 }
             },
             {
+                "Upper Overworld",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Overworld above Patrol Cave",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Patrol Cave",
+                            },
+                            new List<string> {
+                                "Wand",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld above Quarry Entrance",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                            new List<string> {
+                                "Wand",
+                            },
+                        }
+                    },
+                    {
+                        "Overworld after Temple Rafters",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladder near Temple Rafters",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Overworld after Temple Rafters",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Upper Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladder near Temple Rafters",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Overworld above Quarry Entrance",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Dark Tomb",
+                            },
+                        }
+                    },
+                    {
+                        "Upper Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                            new List<string> {
+                                "Wand",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Overworld Quarry Entry",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Overworld after Envoy",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladder to Quarry",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Overworld after Envoy",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                            new List<string> {
+                                "Wand",
+                            },
+                            new List<string> {
+                                "Heir Sword",  // implement this
+                            },
+                        }
+                    },
+                    {
+                        "Overworld Quarry Entry",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladder to Quarry",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "After Ruined Passage",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Weathervane",
+                            },
+                        }
+                    },
+                    {
+                        "Above Ruined Passage",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Weathervane",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Above Ruined Passage",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Weathervane",
+                            },
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                        }
+                    },
+                    {
+                        "After Ruined Passage",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Weathervane",
+                            },
+                        }
+                    },
+                    {
+                        "East Overworld",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders near Weathervane",
+                            },
+                        }
+                    },
+                }
+            },
+            {
                 "Old House Front",
                 new Dictionary<string, List<List<string>>> {
                     {

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -3904,23 +3904,7 @@ namespace TunicRandomizer {
                         "Eastern Vault Fortress Gold Door",
                         new List<List<string>> {
                             new List<string> {
-                                "Wand", "Stundagger", "nmg",
-                            },
-                            new List<string> {
                                 "12", "Fortress Exterior from Overworld", "Beneath the Vault Back", "Fortress Courtyard Upper",
-                            },
-                        }
-                    },
-                }
-            },
-            {
-                "Eastern Vault Fortress Gold Door",
-                new Dictionary<string, List<List<string>>> {
-                    {
-                        "Eastern Vault Fortress",
-                        new List<List<string>> {
-                            new List<string> {
-                                "Wand", "Stundagger", "nmg",
                             },
                         }
                     },
@@ -3942,19 +3926,6 @@ namespace TunicRandomizer {
                         new List<List<string>> {
                             new List<string> {
                                 "Hyperdash",
-                            },
-                        }
-                    },
-                }
-            },
-            {
-                "Fortress Grave Path Upper",
-                new Dictionary<string, List<List<string>>> {
-                    {
-                        "Fortress Grave Path",
-                        new List<List<string>> {
-                            new List<string> {
-                                "26", "Stundagger", "Techbow", "Wand", "nmg",
                             },
                         }
                     },
@@ -4036,14 +4007,6 @@ namespace TunicRandomizer {
                 "Monastery Back",
                 new Dictionary<string, List<List<string>>> {
                     {
-                        "Monastery Front",
-                        new List<List<string>> {
-                            new List<string> {
-                                "Hyperdash", "nmg",
-                            },
-                        }
-                    },
-                    {
                         "Monastery Hero's Grave",
                         new List<List<string>> {
                             new List<string> {
@@ -4069,12 +4032,6 @@ namespace TunicRandomizer {
                     {
                         "Monastery Back",
                         new List<List<string>> {
-                            new List<string> {
-                                "Sword"
-                            },
-                            new List<string> {
-                                "Techbow"
-                            }
                         }
                     },
                 }
@@ -4135,14 +4092,6 @@ namespace TunicRandomizer {
                             },
                         }
                     },
-                    {
-                        "Monastery Rope",
-                        new List<List<string>> {
-                            new List<string> {
-                                "Ladder Storage",
-                            },
-                        }
-                    },
                 }
             },
             {
@@ -4199,6 +4148,19 @@ namespace TunicRandomizer {
             },
             {
                 "Lower Quarry",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Even Lower Quarry",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Lower Quarry"
+                            }
+                        }
+                    },
+                }
+            },
+            {
+                "Even Lower Quarry",
                 new Dictionary<string, List<List<string>>> {
                     {
                         "Lower Quarry Zig Door",
@@ -4294,9 +4256,6 @@ namespace TunicRandomizer {
                             new List<string> {
                                 "Hyperdash", "Sword", "12"
                             },
-                            new List<string> {
-                                "Ladder Storage",
-                            },
                         }
                     },
                     {
@@ -4356,16 +4315,61 @@ namespace TunicRandomizer {
                 }
             },
             {
-                "Swamp",
+                "Swamp Front",
                 new Dictionary<string, List<List<string>>> {
+                    {
+                        "Swamp Mid",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Swamp",
+                            },
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Swamp Mid",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Swamp Front",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Swamp",
+                            },
+                            new List<string> {
+                                "Hyperdash",
+                            },
+                        }
+                    },
                     {
                         "Swamp to Cathedral Main Entrance",
                         new List<List<string>> {
                             new List<string> {
                                 "12", "Hyperdash",
                             },
+                        }
+                    },
+                    {
+                        "Swamp Ledge under Cathedral Door",
+                        new List<List<string>> {
                             new List<string> {
-                                "Stundagger", "Wand", "nmg",
+                                "Ladders in Swamp",
+                            },
+                        }
+                    },
+                }
+            },
+            {
+                "Swamp Ledge under Cathedral Door",
+                new Dictionary<string, List<List<string>>> {
+                    {
+                        "Swamp Mid",
+                        new List<List<string>> {
+                            new List<string> {
+                                "Ladders in Swamp",
                             },
                         }
                     },
@@ -4377,21 +4381,13 @@ namespace TunicRandomizer {
                             },
                         }
                     },
-                    {
-                        "Back of Swamp",
-                        new List<List<string>> {
-                            new List<string> {
-                                "Ladder Storage",
-                            },
-                        }
-                    },
                 }
             },
             {
-                "Swamp to Cathedral Treasure Room Entrance",
+                "Swamp to Cathedral Treasure Room",
                 new Dictionary<string, List<List<string>>> {
                     {
-                        "Swamp",
+                        "Swamp Ledge under Cathedral Door",
                         new List<List<string>> {
                         }
                     },
@@ -4419,9 +4415,6 @@ namespace TunicRandomizer {
                             new List<string> {
                                 "Hyperdash",
                             },
-                            new List<string> {
-                                "Ladder Storage",
-                            },
                         }
                     },
                     {
@@ -4442,14 +4435,6 @@ namespace TunicRandomizer {
                         new List<List<string>> {
                             new List<string> {
                                 "Hyperdash",
-                            },
-                        }
-                    },
-                    {
-                        "Swamp",
-                        new List<List<string>> {
-                            new List<string> {
-                                "26", "Wand", "Techbow", "Stundagger", "nmg",
                             },
                         }
                     },

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -5040,6 +5040,7 @@ namespace TunicRandomizer {
                 FullInventory.Remove("Hyperdash");
             }
             FullInventory.Add(start_region, 1);
+            FullInventory = ItemRandomizer.AddListToDict(FullInventory, ItemRandomizer.LadderItems);
             FullInventory = UpdateReachableRegions(FullInventory);
 
             // get the total number of regions to get before doing dead ends

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -1628,7 +1628,7 @@ namespace TunicRandomizer {
             },
             {
                 "Lower Forest",
-                new RegionInfo("Town Basement", true)
+                new RegionInfo("East Forest Redux", false)
             },
             {
                 "Guard House 1 East",
@@ -1840,7 +1840,7 @@ namespace TunicRandomizer {
             },
             {
                 "Library Lab to Librarian",
-                new RegionInfo("Library Arena", true)
+                new RegionInfo("Library Arena", false)
             },
             {
                 "Library Arena",
@@ -3310,9 +3310,6 @@ namespace TunicRandomizer {
                             new List<string> {
                                 "Hyperdash"
                             },
-                            new List<string> {
-                                "Ladder Storage"
-                            },
                         }
                     },
                     {
@@ -3321,9 +3318,6 @@ namespace TunicRandomizer {
                             new List<string> {
                                 "Sword"
                             },
-                            new List<string> {
-                                "Ladder Storage"
-                            },
                         }
                     },
                     {
@@ -3331,14 +3325,6 @@ namespace TunicRandomizer {
                         new List<List<string>> {
                             new List<string> {
                                 "12"
-                            },
-                        }
-                    },
-                    {
-                        "West Garden Portal Item",
-                        new List<List<string>> {
-                            new List<string> {
-                                "26", "Wand", "Stundagger", "Techbow", "nmg"
                             },
                         }
                     },
@@ -5060,7 +5046,7 @@ namespace TunicRandomizer {
             }
 
             int comboNumber = 0;
-            while (FullInventory.Count < total_nondeadend_count + MaxItems.Count) {
+            while (FullInventory.Count - MaxItems.Count - ItemRandomizer.LadderItems.Count < total_nondeadend_count) {
                 ShuffleList(twoPlusPortals, seed);
                 Portal portal1 = null;
                 Portal portal2 = null;

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -4480,19 +4480,6 @@ namespace TunicRandomizer {
                 }
             },
             {
-                "Swamp to Cathedral Main Entrance",
-                new Dictionary<string, List<List<string>>> {
-                    {
-                        "Swamp",
-                        new List<List<string>> {
-                            new List<string> {
-                                "Stundagger", "Wand", "nmg",
-                            },
-                        }
-                    },
-                }
-            },
-            {
                 "Back of Swamp",
                 new Dictionary<string, List<List<string>>> {
                     {
@@ -4816,6 +4803,7 @@ namespace TunicRandomizer {
                         met = true;
                     }
                     // check through each list of requirements
+                    int met_count = 0;
                     foreach (List<string> reqs in destination_group.Value) {
                         if (reqs.Count == 0) {
                             // if a group is empty, you can just walk there
@@ -4823,7 +4811,7 @@ namespace TunicRandomizer {
                             //Logger.LogInfo("group is empty, so met is true");
                         } else {
                             // check if we have the items in our inventory to traverse this path
-                            int met_count = 0;
+                            met_count = 0;
                             foreach (string req in reqs) {
                                 //Logger.LogInfo("req is " + req);
                                 // if sword progression is on, check for this too
@@ -4831,16 +4819,14 @@ namespace TunicRandomizer {
                                     if (inventory.ContainsKey("Sword Progression") && inventory["Sword Progression"] >= 2) {
                                         met_count++;
                                     }
-                                }
-
-                                if (req == "Stick") {
+                                } else if (req == "Stick") {
                                     if (inventory.ContainsKey("Sword Progression")) {
                                         met_count++;
                                     }
-                                }
-
-                                if (inventory.ContainsKey(req)) {
+                                } else if (inventory.ContainsKey(req)) {
                                     met_count++;
+                                    //Logger.LogInfo("met_count is " + met_count);
+                                    //Logger.LogInfo("reqs.count is " + reqs.Count);
                                     //Logger.LogInfo("we met this requirement");
                                 }
                             }


### PR DESCRIPTION
Adds the new regions that ladder shuffle uses.
Partially implements ladder shuffle support, but not all the way, since I'm not sure what you want for the option and such or how to like, turn on making the ladders not show up.