### PR TITLE
Add directions to portals

### DIFF
--- a/src/Patches/ModelSwaps.cs
+++ b/src/Patches/ModelSwaps.cs
@@ -168,6 +168,12 @@ namespace TunicRandomizer {
             ItemPresentationPatches.SetupHexagonQuestItemPresentation();
             ItemPresentationPatches.SetupCapePresentation();
             InitializeExtras();
+
+            // make it so you can pick up money from further away
+            List<ItemPickup> coins = Resources.FindObjectsOfTypeAll<ItemPickup>().Where(coin => coin.gameObject.scene.name == "DontDestroyOnLoad").ToList();
+            foreach (ItemPickup coin in coins) {
+                coin.minimumAttractDistance = 6.5f;
+            }
         }
 
         public static void CreateOtherWorldItemBlocks() {

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -501,7 +501,7 @@ namespace TunicRandomizer {
                         new List<TunicPortal> {
                             new TunicPortal("Atoll Upper Exit", "Overworld Redux", "_upper", PDir.NORTH),
                             new TunicPortal("Atoll Shop", "Shop", "_", PDir.NORTH),
-                            new TunicPortal("Frog Stairs Eye Entrance", "Frog Stairs", "_eye", PDir.NORTH),  // camera rotates, connects to a north
+                            new TunicPortal("Frog Stairs Eye Entrance", "Frog Stairs", "_eye", PDir.SOUTH),  // camera rotates to appear north
                         }
                     },
                     {
@@ -573,7 +573,7 @@ namespace TunicRandomizer {
                     {
                         "Library Exterior Ladder",
                         new List<TunicPortal> {
-                            new TunicPortal("Library Exterior Ladder", "Library Hall", "_", PDir.NORTH),  // camera rotates, connects to an east
+                            new TunicPortal("Library Exterior Ladder", "Library Hall", "_", PDir.WEST),  // camera rotates to appear north
                         }
                     },
                 }
@@ -919,7 +919,7 @@ namespace TunicRandomizer {
                     {
                         "Lower Mountain",
                         new List<TunicPortal> {
-                            new TunicPortal("Mountain to Quarry", "Quarry Redux", "_", PDir.EAST),  // north, then camera rotates
+                            new TunicPortal("Mountain to Quarry", "Quarry Redux", "_", PDir.NORTH),  // camera rotates to look west
                             new TunicPortal("Mountain to Overworld", "Overworld Redux", "_", PDir.SOUTH),
                         }
                     },

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -822,17 +822,17 @@ namespace TunicRandomizer {
                     {
                         "Eastern Vault Fortress",
                         new List<TunicPortal> {
-                            new TunicPortal("Fortress Interior Main Exit", "Fortress Courtyard", "_Big Door"),
-                            new TunicPortal("Fortress Interior to Beneath the Earth", "Fortress Basement", "_"),
-                            new TunicPortal("Fortress Interior Shop", "Shop", "_"),
-                            new TunicPortal("Fortress Interior to East Fortress Upper", "Fortress East", "_upper"),
-                            new TunicPortal("Fortress Interior to East Fortress Lower", "Fortress East", "_lower"),
+                            new TunicPortal("Fortress Interior Main Exit", "Fortress Courtyard", "_Big Door", PDir.SOUTH),
+                            new TunicPortal("Fortress Interior to Beneath the Earth", "Fortress Basement", "_", PDir.WEST),
+                            new TunicPortal("Fortress Interior Shop", "Shop", "_", PDir.NORTH),
+                            new TunicPortal("Fortress Interior to East Fortress Upper", "Fortress East", "_upper", PDir.EAST),
+                            new TunicPortal("Fortress Interior to East Fortress Lower", "Fortress East", "_lower", PDir.EAST),
                         }
                     },
                     {
                         "Eastern Vault Fortress Gold Door",
                         new List<TunicPortal> {
-                            new TunicPortal("Fortress Interior to Siege Engine Arena", "Fortress Arena", "_"),
+                            new TunicPortal("Fortress Interior to Siege Engine Arena", "Fortress Arena", "_", PDir.NORTH),
                         }
                     },
                 }
@@ -843,14 +843,14 @@ namespace TunicRandomizer {
                     {
                         "Fortress East Shortcut Lower",
                         new List<TunicPortal> {
-                            new TunicPortal("East Fortress to Interior Lower", "Fortress Main", "_lower"),
+                            new TunicPortal("East Fortress to Interior Lower", "Fortress Main", "_lower", PDir.WEST),
                         }
                     },
                     {
                         "Fortress East Shortcut Upper",
                         new List<TunicPortal> {
-                            new TunicPortal("East Fortress to Courtyard", "Fortress Courtyard", "_"),
-                            new TunicPortal("East Fortress to Interior Upper", "Fortress Main", "_upper"),
+                            new TunicPortal("East Fortress to Courtyard", "Fortress Courtyard", "_", PDir.WEST),
+                            new TunicPortal("East Fortress to Interior Upper", "Fortress Main", "_upper", PDir.SOUTH),
                         }
                     },
                 }
@@ -861,14 +861,14 @@ namespace TunicRandomizer {
                     {
                         "Fortress Grave Path",
                         new List<TunicPortal> {
-                            new TunicPortal("Fortress Grave Path Lower Exit", "Fortress Courtyard", "_Lower"),
+                            new TunicPortal("Fortress Grave Path Lower Exit", "Fortress Courtyard", "_Lower", PDir.WEST),
                             new TunicPortal("Fortress Hero's Grave", "RelicVoid", "_teleporter_relic plinth", PDir.FLOOR),
                         }
                     },
                     {
                         "Fortress Grave Path Upper",
                         new List<TunicPortal> {
-                            new TunicPortal("Fortress Grave Path Upper Exit", "Fortress Courtyard", "_Upper"),
+                            new TunicPortal("Fortress Grave Path Upper Exit", "Fortress Courtyard", "_Upper", PDir.WEST),
                         }
                     },
                     {

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -9,15 +9,34 @@ namespace TunicRandomizer {
         private static ManualLogSource Logger = TunicRandomizer.Logger;
         public static Dictionary<string, PortalCombo> RandomizedPortals = new Dictionary<string, PortalCombo>();
 
+        // the direction you move while entering the portal
+        public enum PDir {
+            NORTH,
+            SOUTH,
+            EAST,
+            WEST,
+            FLOOR,
+            LADDER_UP,
+            LADDER_DOWN
+        }
+
         public class TunicPortal {
             public string Name;
             public string Destination;
             public string Tag;
+            public int Direction;
 
             public TunicPortal(string name, string destination, string tag) {
                 Name = name;
                 Destination = destination;
                 Tag = tag;
+            }
+
+            public TunicPortal(string name, string destination, string tag, PDir direction) {
+                Name = name;
+                Destination = destination;
+                Tag = tag;
+                Direction = (int) direction;
             }
         }
         
@@ -38,11 +57,11 @@ namespace TunicRandomizer {
                     {
                         "Overworld",
                         new List<TunicPortal> {
-                            new TunicPortal("Stick House Entrance", "Sword Cave", "_"),
-                            new TunicPortal("Windmill Entrance", "Windmill", "_"),
-                            new TunicPortal("Well Ladder Entrance", "Sewer", "_entrance"),
-                            new TunicPortal("Old House Waterfall Entrance", "Overworld Interiors", "_under_checkpoint"),
-                            new TunicPortal("Entrance to Furnace under Windmill", "Furnace", "_gyro_upper_east"),
+                            new TunicPortal("Stick House Entrance", "Sword Cave", "_", PDir.NORTH),
+                            new TunicPortal("Windmill Entrance", "Windmill", "_", PDir.NORTH),
+                            new TunicPortal("Well Ladder Entrance", "Sewer", "_entrance", PDir.LADDER_DOWN),
+                            new TunicPortal("Old House Waterfall Entrance", "Overworld Interiors", "_under_checkpoint", PDir.EAST),
+                            new TunicPortal("Entrance to Furnace under Windmill", "Furnace", "_gyro_upper_east", PDir.WEST),
                             new TunicPortal("Entrance to Furnace from Beach", "Furnace", "_gyro_lower"),
                             new TunicPortal("Caustic Light Cave Entrance", "Overworld Cave", "_"),
                             new TunicPortal("Swamp Lower Entrance", "Swamp Redux 2", "_conduit"),

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -501,7 +501,7 @@ namespace TunicRandomizer {
                         new List<TunicPortal> {
                             new TunicPortal("Atoll Upper Exit", "Overworld Redux", "_upper", PDir.NORTH),
                             new TunicPortal("Atoll Shop", "Shop", "_", PDir.NORTH),
-                            new TunicPortal("Frog Stairs Eye Entrance", "Frog Stairs", "_eye", PDir.NORTH),  // connects to a north
+                            new TunicPortal("Frog Stairs Eye Entrance", "Frog Stairs", "_eye", PDir.NORTH),  // camera rotates, connects to a north
                         }
                     },
                     {
@@ -573,7 +573,7 @@ namespace TunicRandomizer {
                     {
                         "Library Exterior Ladder",
                         new List<TunicPortal> {
-                            new TunicPortal("Library Exterior Ladder", "Library Hall", "_", PDir.NORTH),  // connects to an east
+                            new TunicPortal("Library Exterior Ladder", "Library Hall", "_", PDir.NORTH),  // camera rotates, connects to an east
                         }
                     },
                 }
@@ -666,7 +666,7 @@ namespace TunicRandomizer {
                     {
                         "East Forest Portal",
                         new List<TunicPortal> {
-                            new TunicPortal("Forest to Far Shore", "Transit", "_teleporter_forest teleporter"),
+                            new TunicPortal("Forest to Far Shore", "Transit", "_teleporter_forest teleporter", PDir.FLOOR),
                         }
                     },
                 }
@@ -708,7 +708,7 @@ namespace TunicRandomizer {
                     {
                         "Forest Hero's Grave",
                         new List<TunicPortal> {
-                            new TunicPortal("East Forest Hero's Grave", "RelicVoid", "_teleporter_relic plinth"),
+                            new TunicPortal("East Forest Hero's Grave", "RelicVoid", "_teleporter_relic plinth", PDir.FLOOR),
                         }
                     },
                 }
@@ -862,7 +862,7 @@ namespace TunicRandomizer {
                         "Fortress Grave Path",
                         new List<TunicPortal> {
                             new TunicPortal("Fortress Grave Path Lower Exit", "Fortress Courtyard", "_Lower"),
-                            new TunicPortal("Fortress Hero's Grave", "RelicVoid", "_teleporter_relic plinth"),
+                            new TunicPortal("Fortress Hero's Grave", "RelicVoid", "_teleporter_relic plinth", PDir.FLOOR),
                         }
                     },
                     {
@@ -874,7 +874,7 @@ namespace TunicRandomizer {
                     {
                         "Fortress Grave Path Dusty Entrance",
                         new List<TunicPortal> {
-                            new TunicPortal("Fortress Grave Path Dusty Entrance", "Dusty", "_"),
+                            new TunicPortal("Fortress Grave Path Dusty Entrance", "Dusty", "_", PDir.NORTH),
                         }
                     },
                 }
@@ -885,7 +885,7 @@ namespace TunicRandomizer {
                     {
                         "Fortress Leaf Piles",
                         new List<TunicPortal> {
-                            new TunicPortal("Dusty Exit", "Fortress Reliquary", "_"),
+                            new TunicPortal("Dusty Exit", "Fortress Reliquary", "_", PDir.SOUTH),
                         }
                     },
                 }
@@ -896,13 +896,13 @@ namespace TunicRandomizer {
                     {
                         "Fortress Arena",
                         new List<TunicPortal> {
-                            new TunicPortal("Siege Engine Arena to Fortress", "Fortress Main", "_"),
+                            new TunicPortal("Siege Engine Arena to Fortress", "Fortress Main", "_", PDir.SOUTH),
                         }
                     },
                     {
                         "Fortress Arena Portal",
                         new List<TunicPortal> {
-                            new TunicPortal("Fortress to Far Shore", "Transit", "_teleporter_spidertank"),
+                            new TunicPortal("Fortress to Far Shore", "Transit", "_teleporter_spidertank", PDir.FLOOR),
                         }
                     },
                 }
@@ -979,13 +979,13 @@ namespace TunicRandomizer {
                     {
                         "Lower Quarry Zig Door",
                         new List<TunicPortal> {
-                            new TunicPortal("Quarry to Ziggurat", "ziggurat2020_0", "_"),
+                            new TunicPortal("Quarry to Ziggurat", "ziggurat2020_0", "_", PDir.NORTH),
                         }
                     },
                     {
                         "Quarry Portal",
                         new List<TunicPortal> {
-                            new TunicPortal("Quarry to Far Shore", "Transit", "_teleporter_quarry teleporter"),
+                            new TunicPortal("Quarry to Far Shore", "Transit", "_teleporter_quarry teleporter", PDir.FLOOR),
                         }
                     },
                 }
@@ -1008,7 +1008,7 @@ namespace TunicRandomizer {
                     {
                         "Monastery Hero's Grave",
                         new List<TunicPortal> {
-                            new TunicPortal("Monastery Hero's Grave", "RelicVoid", "_teleporter_relic plinth"),
+                            new TunicPortal("Monastery Hero's Grave", "RelicVoid", "_teleporter_relic plinth", PDir.FLOOR),
                         }
                     },
                 }
@@ -1094,7 +1094,7 @@ namespace TunicRandomizer {
                     {
                         "Rooted Ziggurat Portal",
                         new List<TunicPortal> {
-                            new TunicPortal("Ziggurat to Far Shore", "Transit", "_teleporter_ziggurat teleporter"),
+                            new TunicPortal("Ziggurat to Far Shore", "Transit", "_teleporter_ziggurat teleporter", PDir.FLOOR),
                         }
                     },
                 }
@@ -1136,7 +1136,7 @@ namespace TunicRandomizer {
                     {
                         "Swamp Hero's Grave",
                         new List<TunicPortal> {
-                            new TunicPortal("Swamp Hero's Grave", "RelicVoid", "_teleporter_relic plinth"),
+                            new TunicPortal("Swamp Hero's Grave", "RelicVoid", "_teleporter_relic plinth", PDir.FLOOR),
                         }
                     },
                 }
@@ -1183,37 +1183,37 @@ namespace TunicRandomizer {
                     {
                         "Hero Relic - Fortress",
                         new List<TunicPortal> {
-                            new TunicPortal("Hero's Grave to Fortress", "Fortress Reliquary", "_teleporter_relic plinth"),
+                            new TunicPortal("Hero's Grave to Fortress", "Fortress Reliquary", "_teleporter_relic plinth", PDir.FLOOR),
                         }
                     },
                     {
                         "Hero Relic - Quarry",
                         new List<TunicPortal> {
-                            new TunicPortal("Hero's Grave to Monastery", "Monastery", "_teleporter_relic plinth"),
+                            new TunicPortal("Hero's Grave to Monastery", "Monastery", "_teleporter_relic plinth", PDir.FLOOR),
                         }
                     },
                     {
                         "Hero Relic - West Garden",
                         new List<TunicPortal> {
-                            new TunicPortal("Hero's Grave to West Garden", "Archipelagos Redux", "_teleporter_relic plinth"),
+                            new TunicPortal("Hero's Grave to West Garden", "Archipelagos Redux", "_teleporter_relic plinth", PDir.FLOOR),
                         }
                     },
                     {
                         "Hero Relic - East Forest",
                         new List<TunicPortal> {
-                            new TunicPortal("Hero's Grave to East Forest", "Sword Access", "_teleporter_relic plinth"),
+                            new TunicPortal("Hero's Grave to East Forest", "Sword Access", "_teleporter_relic plinth", PDir.FLOOR),
                         }
                     },
                     {
                         "Hero Relic - Library",
                         new List<TunicPortal> {
-                            new TunicPortal("Hero's Grave to Library", "Library Hall", "_teleporter_relic plinth"),
+                            new TunicPortal("Hero's Grave to Library", "Library Hall", "_teleporter_relic plinth", PDir.FLOOR),
                         }
                     },
                     {
                         "Hero Relic - Swamp",
                         new List<TunicPortal> {
-                            new TunicPortal("Hero's Grave to Swamp", "Swamp Redux 2", "_teleporter_relic plinth"),
+                            new TunicPortal("Hero's Grave to Swamp", "Swamp Redux 2", "_teleporter_relic plinth", PDir.FLOOR),
                         }
                     },
                 }
@@ -1224,46 +1224,46 @@ namespace TunicRandomizer {
                     {
                         "Far Shore to West Garden",
                         new List<TunicPortal> {
-                            new TunicPortal("Far Shore to West Garden", "Archipelagos Redux", "_teleporter_archipelagos_teleporter"),
+                            new TunicPortal("Far Shore to West Garden", "Archipelagos Redux", "_teleporter_archipelagos_teleporter", PDir.FLOOR),
                         }
                     },
                     {
                         "Far Shore to Library",
                         new List<TunicPortal> {
-                            new TunicPortal("Far Shore to Library", "Library Lab", "_teleporter_library teleporter"),
+                            new TunicPortal("Far Shore to Library", "Library Lab", "_teleporter_library teleporter", PDir.FLOOR),
                         }
                     },
                     {
                         "Far Shore to Quarry",
                         new List<TunicPortal> {
-                            new TunicPortal("Far Shore to Quarry", "Quarry Redux", "_teleporter_quarry teleporter"),
+                            new TunicPortal("Far Shore to Quarry", "Quarry Redux", "_teleporter_quarry teleporter", PDir.FLOOR),
                         }
                     },
                     {
                         "Far Shore to East Forest",
                         new List<TunicPortal> {
-                            new TunicPortal("Far Shore to East Forest", "East Forest Redux", "_teleporter_forest teleporter"),
+                            new TunicPortal("Far Shore to East Forest", "East Forest Redux", "_teleporter_forest teleporter", PDir.FLOOR),
                         }
                     },
                     {
                         "Far Shore to Fortress",
                         new List<TunicPortal> {
-                            new TunicPortal("Far Shore to Fortress", "Fortress Arena", "_teleporter_spidertank"),
+                            new TunicPortal("Far Shore to Fortress", "Fortress Arena", "_teleporter_spidertank", PDir.FLOOR),
                         }
                     },
                     {
                         "Far Shore",
                         new List<TunicPortal> {
-                            new TunicPortal("Far Shore to Atoll", "Atoll Redux", "_teleporter_atoll"),
-                            new TunicPortal("Far Shore to Ziggurat", "ziggurat2020_FTRoom", "_teleporter_ziggurat teleporter"),
-                            new TunicPortal("Far Shore to Heir", "Spirit Arena", "_teleporter_spirit arena"),
-                            new TunicPortal("Far Shore to Town", "Overworld Redux", "_teleporter_town"),
+                            new TunicPortal("Far Shore to Atoll", "Atoll Redux", "_teleporter_atoll", PDir.FLOOR),
+                            new TunicPortal("Far Shore to Ziggurat", "ziggurat2020_FTRoom", "_teleporter_ziggurat teleporter", PDir.FLOOR),
+                            new TunicPortal("Far Shore to Heir", "Spirit Arena", "_teleporter_spirit arena", PDir.FLOOR),
+                            new TunicPortal("Far Shore to Town", "Overworld Redux", "_teleporter_town", PDir.FLOOR),
                         }
                     },
                     {
                         "Far Shore to Spawn",
                         new List<TunicPortal> {
-                            new TunicPortal("Far Shore to Spawn", "Overworld Redux", "_teleporter_starting island"),
+                            new TunicPortal("Far Shore to Spawn", "Overworld Redux", "_teleporter_starting island", PDir.FLOOR),
                         }
                     },
                 }
@@ -1274,7 +1274,7 @@ namespace TunicRandomizer {
                     {
                         "Spirit Arena",
                         new List<TunicPortal> {
-                            new TunicPortal("Heir Arena Exit", "Transit", "_teleporter_spirit arena"),
+                            new TunicPortal("Heir Arena Exit", "Transit", "_teleporter_spirit arena", PDir.FLOOR),
                         }
                     },
                 }

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -62,105 +62,105 @@ namespace TunicRandomizer {
                             new TunicPortal("Well Ladder Entrance", "Sewer", "_entrance", PDir.LADDER_DOWN),
                             new TunicPortal("Old House Waterfall Entrance", "Overworld Interiors", "_under_checkpoint", PDir.EAST),
                             new TunicPortal("Entrance to Furnace under Windmill", "Furnace", "_gyro_upper_east", PDir.WEST),
-                            new TunicPortal("Entrance to Furnace from Beach", "Furnace", "_gyro_lower"),
-                            new TunicPortal("Caustic Light Cave Entrance", "Overworld Cave", "_"),
-                            new TunicPortal("Swamp Lower Entrance", "Swamp Redux 2", "_conduit"),
-                            new TunicPortal("Ruined Passage Not-Door Entrance", "Ruins Passage", "_east"),
-                            new TunicPortal("Atoll Upper Entrance", "Atoll Redux", "_upper"),
-                            new TunicPortal("Atoll Lower Entrance", "Atoll Redux", "_lower"),
-                            new TunicPortal("Maze Cave Entrance", "Maze Room", "_"),
-                            new TunicPortal("Temple Rafters Entrance", "Temple", "_rafters"),
-                            new TunicPortal("Ruined Shop Entrance", "Ruined Shop", "_"),
-                            new TunicPortal("Patrol Cave Entrance", "PatrolCave", "_"),
-                            new TunicPortal("Hourglass Cave Entrance", "Town Basement", "_beach"),
-                            new TunicPortal("Changing Room Entrance", "Changing Room", "_"),
-                            new TunicPortal("Cube Cave Entrance", "CubeRoom", "_"),
-                            new TunicPortal("Stairs from Overworld to Mountain", "Mountain", "_"),
-                            new TunicPortal("Overworld to Fortress", "Fortress Courtyard", "_"),
-                            new TunicPortal("Overworld to Quarry Connector", "Darkwoods Tunnel", "_"),
-                            new TunicPortal("Dark Tomb Main Entrance", "Crypt Redux", "_"),
-                            new TunicPortal("Overworld to Forest Belltower", "Forest Belltower", "_"),
-                            new TunicPortal("Secret Gathering Place Entrance", "Waterfall", "_"),
+                            new TunicPortal("Entrance to Furnace from Beach", "Furnace", "_gyro_lower", PDir.NORTH),
+                            new TunicPortal("Caustic Light Cave Entrance", "Overworld Cave", "_", PDir.NORTH),
+                            new TunicPortal("Swamp Lower Entrance", "Swamp Redux 2", "_conduit", PDir.SOUTH),
+                            new TunicPortal("Ruined Passage Not-Door Entrance", "Ruins Passage", "_east", PDir.WEST),
+                            new TunicPortal("Atoll Upper Entrance", "Atoll Redux", "_upper", PDir.SOUTH),
+                            new TunicPortal("Atoll Lower Entrance", "Atoll Redux", "_lower", PDir.SOUTH),
+                            new TunicPortal("Maze Cave Entrance", "Maze Room", "_", PDir.NORTH),
+                            new TunicPortal("Temple Rafters Entrance", "Temple", "_rafters", PDir.EAST),
+                            new TunicPortal("Ruined Shop Entrance", "Ruined Shop", "_", PDir.EAST),
+                            new TunicPortal("Patrol Cave Entrance", "PatrolCave", "_", PDir.NORTH),
+                            new TunicPortal("Hourglass Cave Entrance", "Town Basement", "_beach", PDir.NORTH),
+                            new TunicPortal("Changing Room Entrance", "Changing Room", "_", PDir.SOUTH),
+                            new TunicPortal("Cube Cave Entrance", "CubeRoom", "_", PDir.NORTH),
+                            new TunicPortal("Stairs from Overworld to Mountain", "Mountain", "_", PDir.NORTH),
+                            new TunicPortal("Overworld to Fortress", "Fortress Courtyard", "_", PDir.EAST),
+                            new TunicPortal("Overworld to Quarry Connector", "Darkwoods Tunnel", "_", PDir.NORTH),
+                            new TunicPortal("Dark Tomb Main Entrance", "Crypt Redux", "_", PDir.NORTH),
+                            new TunicPortal("Overworld to Forest Belltower", "Forest Belltower", "_", PDir.EAST),
+                            new TunicPortal("Secret Gathering Place Entrance", "Waterfall", "_", PDir.NORTH),
                         }
                     },
                     {
                         "Overworld Well to Furnace Rail",
                         new List<TunicPortal> {
-                            new TunicPortal("Entrance to Well from Well Rail", "Sewer", "_west_aqueduct"),
-                            new TunicPortal("Entrance to Furnace from Well Rail", "Furnace", "_gyro_upper_north"),
+                            new TunicPortal("Entrance to Well from Well Rail", "Sewer", "_west_aqueduct", PDir.NORTH),
+                            new TunicPortal("Entrance to Furnace from Well Rail", "Furnace", "_gyro_upper_north", PDir.SOUTH),
                         }
                     },
                     {
                         "Overworld Old House Door",
                         new List<TunicPortal> {
-                            new TunicPortal("Old House Door Entrance", "Overworld Interiors", "_house"),
+                            new TunicPortal("Old House Door Entrance", "Overworld Interiors", "_house", PDir.EAST),
                         }
                     },
                     {
                         "Overworld to West Garden from Furnace",
                         new List<TunicPortal> {
-                            new TunicPortal("Entrance to Furnace near West Garden", "Furnace", "_gyro_west"),
-                            new TunicPortal("West Garden Entrance from Furnace", "Archipelagos Redux", "_lower"),
+                            new TunicPortal("Entrance to Furnace near West Garden", "Furnace", "_gyro_west", PDir.EAST),
+                            new TunicPortal("West Garden Entrance from Furnace", "Archipelagos Redux", "_lower", PDir.WEST),
                         }
                     },
                     {
                         "Overworld Swamp Upper Entry",
                         new List<TunicPortal> {
-                            new TunicPortal("Swamp Upper Entrance", "Swamp Redux 2", "_wall"),
+                            new TunicPortal("Swamp Upper Entrance", "Swamp Redux 2", "_wall", PDir.SOUTH),
                         }
                     },
                     {
                         "Overworld Ruined Passage Door",
                         new List<TunicPortal> {
-                            new TunicPortal("Ruined Passage Door Entrance", "Ruins Passage", "_west"),
+                            new TunicPortal("Ruined Passage Door Entrance", "Ruins Passage", "_west", PDir.EAST),
                         }
                     },
                     {
                         "Overworld Special Shop Entry",
                         new List<TunicPortal> {
-                            new TunicPortal("Special Shop Entrance", "ShopSpecial", "_"),
+                            new TunicPortal("Special Shop Entrance", "ShopSpecial", "_", PDir.EAST),
                         }
                     },
                     {
                         "Overworld Belltower",
                         new List<TunicPortal> {
-                            new TunicPortal("West Garden Entrance near Belltower", "Archipelagos Redux", "_upper"),
+                            new TunicPortal("West Garden Entrance near Belltower", "Archipelagos Redux", "_upper", PDir.WEST),
                         }
                     },
                     {
                         "Overworld West Garden Laurels Entry",
                         new List<TunicPortal> {
-                            new TunicPortal("West Garden Laurels Entrance", "Archipelagos Redux", "_lowest"),
+                            new TunicPortal("West Garden Laurels Entrance", "Archipelagos Redux", "_lowest", PDir.WEST),
                         }
                     },
                     {
                         "Overworld Temple Door",
                         new List<TunicPortal> {
-                            new TunicPortal("Temple Door Entrance", "Temple", "_main"),
+                            new TunicPortal("Temple Door Entrance", "Temple", "_main", PDir.NORTH),
                         }
                     },
                     {
                         "Overworld Fountain Cross Door",
                         new List<TunicPortal> {
-                            new TunicPortal("Fountain HC Door Entrance", "Town_FiligreeRoom", "_"),
+                            new TunicPortal("Fountain HC Door Entrance", "Town_FiligreeRoom", "_", PDir.NORTH),
                         }
                     },
                     {
                         "Overworld Southeast Cross Door",
                         new List<TunicPortal> {
-                            new TunicPortal("Southeast HC Door Entrance", "EastFiligreeCache", "_"),
+                            new TunicPortal("Southeast HC Door Entrance", "EastFiligreeCache", "_", PDir.NORTH),
                         }
                     },
                     {
                         "Overworld Town Portal",
                         new List<TunicPortal> {
-                            new TunicPortal("Town to Far Shore", "Transit", "_teleporter_town"),
+                            new TunicPortal("Town to Far Shore", "Transit", "_teleporter_town", PDir.FLOOR),
                         }
                     },
                     {
                         "Overworld Spawn Portal",
                         new List<TunicPortal> {
-                            new TunicPortal("Spawn to Far Shore", "Transit", "_teleporter_starting island"),
+                            new TunicPortal("Spawn to Far Shore", "Transit", "_teleporter_starting island", PDir.FLOOR),
                         }
                     },
                 }
@@ -171,7 +171,7 @@ namespace TunicRandomizer {
                     {
                         "Secret Gathering Place",
                         new List<TunicPortal> {
-                            new TunicPortal("Secret Gathering Place Exit", "Overworld Redux", "_"),
+                            new TunicPortal("Secret Gathering Place Exit", "Overworld Redux", "_", PDir.SOUTH),
                         }
                     },
                 }
@@ -182,8 +182,8 @@ namespace TunicRandomizer {
                     {
                         "Windmill",
                         new List<TunicPortal> {
-                            new TunicPortal("Windmill Exit", "Overworld Redux", "_"),
-                            new TunicPortal("Windmill Shop", "Shop", "_"),
+                            new TunicPortal("Windmill Exit", "Overworld Redux", "_", PDir.SOUTH),
+                            new TunicPortal("Windmill Shop", "Shop", "_", PDir.NORTH),
                         }
                     },
                 }
@@ -194,14 +194,14 @@ namespace TunicRandomizer {
                     {
                         "Old House Front",
                         new List<TunicPortal> {
-                            new TunicPortal("Old House Door Exit", "Overworld Redux", "_house"),
-                            new TunicPortal("Old House to Glyph Tower", "g_elements", "_"),
+                            new TunicPortal("Old House Door Exit", "Overworld Redux", "_house", PDir.WEST),
+                            new TunicPortal("Old House to Glyph Tower", "g_elements", "_", PDir.FLOOR),
                         }
                     },
                     {
                         "Old House Back",
                         new List<TunicPortal> {
-                            new TunicPortal("Old House Waterfall Exit", "Overworld Redux", "_under_checkpoint"),
+                            new TunicPortal("Old House Waterfall Exit", "Overworld Redux", "_under_checkpoint", PDir.WEST),
                         }
                     },
                 }
@@ -212,7 +212,7 @@ namespace TunicRandomizer {
                     {
                         "Relic Tower",
                         new List<TunicPortal> {
-                            new TunicPortal("Glyph Tower Exit", "Overworld Interiors", "_"),
+                            new TunicPortal("Glyph Tower Exit", "Overworld Interiors", "_", PDir.NORTH),
                         }
                     },
                 }
@@ -223,7 +223,7 @@ namespace TunicRandomizer {
                     {
                         "Changing Room",
                         new List<TunicPortal> {
-                            new TunicPortal("Changing Room Exit", "Overworld Redux", "_"),
+                            new TunicPortal("Changing Room Exit", "Overworld Redux", "_", PDir.NORTH),
                         }
                     },
                 }
@@ -234,7 +234,7 @@ namespace TunicRandomizer {
                     {
                         "Fountain Cross Room",
                         new List<TunicPortal> {
-                            new TunicPortal("Fountain HC Room Exit", "Overworld Redux", "_"),
+                            new TunicPortal("Fountain HC Room Exit", "Overworld Redux", "_", PDir.SOUTH),
                         }
                     },
                 }
@@ -245,7 +245,7 @@ namespace TunicRandomizer {
                     {
                         "Cube Cave",
                         new List<TunicPortal> {
-                            new TunicPortal("Cube Cave Exit", "Overworld Redux", "_"),
+                            new TunicPortal("Cube Cave Exit", "Overworld Redux", "_", PDir.SOUTH),
                         }
                     },
                 }
@@ -256,7 +256,7 @@ namespace TunicRandomizer {
                     {
                         "Patrol Cave",
                         new List<TunicPortal> {
-                            new TunicPortal("Guard Patrol Cave Exit", "Overworld Redux", "_"),
+                            new TunicPortal("Guard Patrol Cave Exit", "Overworld Redux", "_", PDir.SOUTH),
                         }
                     },
                 }
@@ -267,7 +267,7 @@ namespace TunicRandomizer {
                     {
                         "Ruined Shop",
                         new List<TunicPortal> {
-                            new TunicPortal("Ruined Shop Exit", "Overworld Redux", "_"),
+                            new TunicPortal("Ruined Shop Exit", "Overworld Redux", "_", PDir.WEST),
                         }
                     },
                 }
@@ -278,21 +278,21 @@ namespace TunicRandomizer {
                     {
                         "Furnace Fuse",
                         new List<TunicPortal> {
-                            new TunicPortal("Furnace Exit towards Well", "Overworld Redux", "_gyro_upper_north"),
+                            new TunicPortal("Furnace Exit towards Well", "Overworld Redux", "_gyro_upper_north", PDir.NORTH),
                         }
                     },
                     {
                         "Furnace Walking Path",
                         new List<TunicPortal> {
-                            new TunicPortal("Furnace Exit to Dark Tomb", "Crypt Redux", "_"),
-                            new TunicPortal("Furnace Exit towards West Garden", "Overworld Redux", "_gyro_west"),
+                            new TunicPortal("Furnace Exit to Dark Tomb", "Crypt Redux", "_", PDir.EAST),
+                            new TunicPortal("Furnace Exit towards West Garden", "Overworld Redux", "_gyro_west", PDir.WEST),
                         }
                     },
                     {
                         "Furnace Ladder Area",
                         new List<TunicPortal> {
-                            new TunicPortal("Furnace Exit to Beach", "Overworld Redux", "_gyro_lower"),
-                            new TunicPortal("Furnace Exit under Windmill", "Overworld Redux", "_gyro_upper_east"),
+                            new TunicPortal("Furnace Exit to Beach", "Overworld Redux", "_gyro_lower", PDir.SOUTH),
+                            new TunicPortal("Furnace Exit under Windmill", "Overworld Redux", "_gyro_upper_east", PDir.EAST),
                         }
                     },
                 }
@@ -303,7 +303,7 @@ namespace TunicRandomizer {
                     {
                         "Stick House",
                         new List<TunicPortal> {
-                            new TunicPortal("Stick House Exit", "Overworld Redux", "_"),
+                            new TunicPortal("Stick House Exit", "Overworld Redux", "_", PDir.SOUTH),
                         }
                     },
                 }
@@ -314,8 +314,8 @@ namespace TunicRandomizer {
                     {
                         "Ruined Passage",
                         new List<TunicPortal> {
-                            new TunicPortal("Ruined Passage Not-Door Exit", "Overworld Redux", "_east"),
-                            new TunicPortal("Ruined Passage Door Exit", "Overworld Redux", "_west"),
+                            new TunicPortal("Ruined Passage Not-Door Exit", "Overworld Redux", "_east", PDir.EAST),
+                            new TunicPortal("Ruined Passage Door Exit", "Overworld Redux", "_west", PDir.WEST),
                         }
                     },
                 }
@@ -326,7 +326,7 @@ namespace TunicRandomizer {
                     {
                         "Southeast Cross Room",
                         new List<TunicPortal> {
-                            new TunicPortal("Southeast HC Room Exit", "Overworld Redux", "_"),
+                            new TunicPortal("Southeast HC Room Exit", "Overworld Redux", "_", PDir.SOUTH),
                         }
                     },
                 }
@@ -337,7 +337,7 @@ namespace TunicRandomizer {
                     {
                         "Caustic Light Cave",
                         new List<TunicPortal> {
-                            new TunicPortal("Caustic Light Cave Exit", "Overworld Redux", "_"),
+                            new TunicPortal("Caustic Light Cave Exit", "Overworld Redux", "_", PDir.SOUTH),
                         }
                     },
                 }
@@ -348,7 +348,7 @@ namespace TunicRandomizer {
                     {
                         "Maze Cave",
                         new List<TunicPortal> {
-                            new TunicPortal("Maze Cave Exit", "Overworld Redux", "_"),
+                            new TunicPortal("Maze Cave Exit", "Overworld Redux", "_", PDir.SOUTH),
                         }
                     },
                 }
@@ -359,7 +359,7 @@ namespace TunicRandomizer {
                     {
                         "Hourglass Cave",
                         new List<TunicPortal> {
-                            new TunicPortal("Hourglass Cave Exit", "Overworld Redux", "_beach"),
+                            new TunicPortal("Hourglass Cave Exit", "Overworld Redux", "_beach", PDir.SOUTH),
                         }
                     },
                 }
@@ -370,7 +370,7 @@ namespace TunicRandomizer {
                     {
                         "Special Shop",
                         new List<TunicPortal> {
-                            new TunicPortal("Special Shop Exit", "Overworld Redux", "_"),
+                            new TunicPortal("Special Shop Exit", "Overworld Redux", "_", PDir.WEST),
                         }
                     },
                 }
@@ -381,13 +381,13 @@ namespace TunicRandomizer {
                     {
                         "Sealed Temple Rafters",
                         new List<TunicPortal> {
-                            new TunicPortal("Temple Rafters Exit", "Overworld Redux", "_rafters"),
+                            new TunicPortal("Temple Rafters Exit", "Overworld Redux", "_rafters", PDir.WEST),
                         }
                     },
                     {
                         "Sealed Temple",
                         new List<TunicPortal> {
-                            new TunicPortal("Temple Door Exit", "Overworld Redux", "_main"),
+                            new TunicPortal("Temple Door Exit", "Overworld Redux", "_main", PDir.SOUTH),
                         }
                     },
                 }
@@ -398,14 +398,14 @@ namespace TunicRandomizer {
                     {
                         "Beneath the Well Front",
                         new List<TunicPortal> {
-                            new TunicPortal("Well Ladder Exit", "Overworld Redux", "_entrance"),
+                            new TunicPortal("Well Ladder Exit", "Overworld Redux", "_entrance", PDir.LADDER_UP),
                         }
                     },
                     {
                         "Beneath the Well Back",
                         new List<TunicPortal> {
-                            new TunicPortal("Well to Well Boss", "Sewer_Boss", "_"),
-                            new TunicPortal("Well Exit towards Furnace", "Overworld Redux", "_west_aqueduct"),
+                            new TunicPortal("Well to Well Boss", "Sewer_Boss", "_", PDir.EAST),
+                            new TunicPortal("Well Exit towards Furnace", "Overworld Redux", "_west_aqueduct", PDir.SOUTH),
                         }
                     },
                 }
@@ -416,13 +416,13 @@ namespace TunicRandomizer {
                     {
                         "Well Boss",
                         new List<TunicPortal> {
-                            new TunicPortal("Well Boss to Well", "Sewer", "_"),
+                            new TunicPortal("Well Boss to Well", "Sewer", "_", PDir.WEST),
                         }
                     },
                     {
                         "Dark Tomb Checkpoint",
                         new List<TunicPortal> {
-                            new TunicPortal("Checkpoint to Dark Tomb", "Crypt Redux", "_"),
+                            new TunicPortal("Checkpoint to Dark Tomb", "Crypt Redux", "_", PDir.LADDER_UP),
                         }
                     },
                 }
@@ -433,14 +433,14 @@ namespace TunicRandomizer {
                     {
                         "Dark Tomb Entry Point",
                         new List<TunicPortal> {
-                            new TunicPortal("Dark Tomb to Overworld", "Overworld Redux", "_"),
-                            new TunicPortal("Dark Tomb to Checkpoint", "Sewer_Boss", "_"),
+                            new TunicPortal("Dark Tomb to Overworld", "Overworld Redux", "_", PDir.SOUTH),
+                            new TunicPortal("Dark Tomb to Checkpoint", "Sewer_Boss", "_", PDir.LADDER_DOWN),
                         }
                     },
                     {
                         "Dark Tomb Dark Exit",
                         new List<TunicPortal> {
-                            new TunicPortal("Dark Tomb to Furnace", "Furnace", "_"),
+                            new TunicPortal("Dark Tomb to Furnace", "Furnace", "_", PDir.WEST),
                         }
                     },
                 }
@@ -451,33 +451,33 @@ namespace TunicRandomizer {
                     {
                         "West Garden",
                         new List<TunicPortal> {
-                            new TunicPortal("West Garden Exit near Hero's Grave", "Overworld Redux", "_lower"),
-                            new TunicPortal("West Garden to Magic Dagger House", "archipelagos_house", "_"),
-                            new TunicPortal("West Garden Shop", "Shop", "_"),
+                            new TunicPortal("West Garden Exit near Hero's Grave", "Overworld Redux", "_lower", PDir.EAST),
+                            new TunicPortal("West Garden to Magic Dagger House", "archipelagos_house", "_", PDir.EAST),
+                            new TunicPortal("West Garden Shop", "Shop", "_", PDir.EAST),
                         }
                     },
                     {
                         "West Garden after Boss",
                         new List<TunicPortal> {
-                            new TunicPortal("West Garden Exit after Boss", "Overworld Redux", "_upper"),
+                            new TunicPortal("West Garden Exit after Boss", "Overworld Redux", "_upper", PDir.EAST),
                         }
                     },
                     {
                         "West Garden Laurels Exit",
                         new List<TunicPortal> {
-                            new TunicPortal("West Garden Laurels Exit", "Overworld Redux", "_lowest"),
+                            new TunicPortal("West Garden Laurels Exit", "Overworld Redux", "_lowest", PDir.EAST),
                         }
                     },
                     {
                         "West Garden Hero's Grave",
                         new List<TunicPortal> {
-                            new TunicPortal("West Garden Hero's Grave", "RelicVoid", "_teleporter_relic plinth"),
+                            new TunicPortal("West Garden Hero's Grave", "RelicVoid", "_teleporter_relic plinth", PDir.FLOOR),
                         }
                     },
                     {
                         "West Garden Portal",
                         new List<TunicPortal> {
-                            new TunicPortal("West Garden to Far Shore", "Transit", "_teleporter_archipelagos_teleporter"),
+                            new TunicPortal("West Garden to Far Shore", "Transit", "_teleporter_archipelagos_teleporter", PDir.FLOOR),
                         }
                     },
                 }
@@ -488,7 +488,7 @@ namespace TunicRandomizer {
                     {
                         "Magic Dagger House",
                         new List<TunicPortal> {
-                            new TunicPortal("Magic Dagger House Exit", "Archipelagos Redux", "_"),
+                            new TunicPortal("Magic Dagger House Exit", "Archipelagos Redux", "_", PDir.WEST),
                         }
                     },
                 }
@@ -499,33 +499,33 @@ namespace TunicRandomizer {
                     {
                         "Ruined Atoll",
                         new List<TunicPortal> {
-                            new TunicPortal("Atoll Upper Exit", "Overworld Redux", "_upper"),
-                            new TunicPortal("Atoll Shop", "Shop", "_"),
-                            new TunicPortal("Frog Stairs Eye Entrance", "Frog Stairs", "_eye"),
+                            new TunicPortal("Atoll Upper Exit", "Overworld Redux", "_upper", PDir.NORTH),
+                            new TunicPortal("Atoll Shop", "Shop", "_", PDir.NORTH),
+                            new TunicPortal("Frog Stairs Eye Entrance", "Frog Stairs", "_eye", PDir.NORTH),  // connects to a north
                         }
                     },
                     {
                         "Ruined Atoll Lower Entry Area",
                         new List<TunicPortal> {
-                            new TunicPortal("Atoll Lower Exit", "Overworld Redux", "_lower"),
+                            new TunicPortal("Atoll Lower Exit", "Overworld Redux", "_lower", PDir.NORTH),
                         }
                     },
                     {
                         "Ruined Atoll Portal",
                         new List<TunicPortal> {
-                            new TunicPortal("Atoll to Far Shore", "Transit", "_teleporter_atoll"),
+                            new TunicPortal("Atoll to Far Shore", "Transit", "_teleporter_atoll", PDir.FLOOR),
                         }
                     },
                     {
                         "Ruined Atoll Statue",
                         new List<TunicPortal> {
-                            new TunicPortal("Atoll Statue Teleporter", "Library Exterior", "_"),
+                            new TunicPortal("Atoll Statue Teleporter", "Library Exterior", "_", PDir.FLOOR),
                         }
                     },
                     {
                         "Ruined Atoll Frog Mouth",
                         new List<TunicPortal> {
-                            new TunicPortal("Frog Stairs Mouth Entrance", "Frog Stairs", "_mouth"),
+                            new TunicPortal("Frog Stairs Mouth Entrance", "Frog Stairs", "_mouth", PDir.EAST),
                         }
                     },
                 }
@@ -536,10 +536,10 @@ namespace TunicRandomizer {
                     {
                         "Frog's Domain Entry",
                         new List<TunicPortal> {
-                            new TunicPortal("Frog Stairs Eye Exit", "Atoll Redux", "_eye"),
-                            new TunicPortal("Frog Stairs Mouth Exit", "Atoll Redux", "_mouth"),
-                            new TunicPortal("Frog Stairs to Frog's Domain's Entrance", "frog cave main", "_Entrance"),
-                            new TunicPortal("Frog Stairs to Frog's Domain's Exit", "frog cave main", "_Exit"),
+                            new TunicPortal("Frog Stairs Eye Exit", "Atoll Redux", "_eye", PDir.NORTH),
+                            new TunicPortal("Frog Stairs Mouth Exit", "Atoll Redux", "_mouth", PDir.WEST),
+                            new TunicPortal("Frog Stairs to Frog's Domain's Entrance", "frog cave main", "_Entrance", PDir.LADDER_DOWN),
+                            new TunicPortal("Frog Stairs to Frog's Domain's Exit", "frog cave main", "_Exit", PDir.EAST),
                         }
                     },
                 }
@@ -550,13 +550,13 @@ namespace TunicRandomizer {
                     {
                         "Frog's Domain",
                         new List<TunicPortal> {
-                            new TunicPortal("Frog's Domain Ladder Exit", "Frog Stairs", "_Entrance"),
+                            new TunicPortal("Frog's Domain Ladder Exit", "Frog Stairs", "_Entrance", PDir.LADDER_UP),
                         }
                     },
                     {
                         "Frog's Domain Back",
                         new List<TunicPortal> {
-                            new TunicPortal("Frog's Domain Orb Exit", "Frog Stairs", "_Exit"),
+                            new TunicPortal("Frog's Domain Orb Exit", "Frog Stairs", "_Exit", PDir.WEST),
                         }
                     },
                 }
@@ -567,13 +567,13 @@ namespace TunicRandomizer {
                     {
                         "Library Exterior Tree",
                         new List<TunicPortal> {
-                            new TunicPortal("Library Exterior Tree", "Atoll Redux", "_"),
+                            new TunicPortal("Library Exterior Tree", "Atoll Redux", "_", PDir.FLOOR),
                         }
                     },
                     {
                         "Library Exterior Ladder",
                         new List<TunicPortal> {
-                            new TunicPortal("Library Exterior Ladder", "Library Hall", "_"),
+                            new TunicPortal("Library Exterior Ladder", "Library Hall", "_", PDir.NORTH),  // connects to an east
                         }
                     },
                 }
@@ -584,14 +584,14 @@ namespace TunicRandomizer {
                     {
                         "Library Hall",
                         new List<TunicPortal> {
-                            new TunicPortal("Library Hall Bookshelf Exit", "Library Exterior", "_"),
-                            new TunicPortal("Library Hall to Rotunda", "Library Rotunda", "_"),
+                            new TunicPortal("Library Hall Bookshelf Exit", "Library Exterior", "_", PDir.EAST),
+                            new TunicPortal("Library Hall to Rotunda", "Library Rotunda", "_", PDir.LADDER_UP),
                         }
                     },
                     {
                         "Library Hero's Grave",
                         new List<TunicPortal> {
-                            new TunicPortal("Library Hero's Grave", "RelicVoid", "_teleporter_relic plinth"),
+                            new TunicPortal("Library Hero's Grave", "RelicVoid", "_teleporter_relic plinth", PDir.FLOOR),
                         }
                     },
                 }
@@ -602,8 +602,8 @@ namespace TunicRandomizer {
                     {
                         "Library Rotunda",
                         new List<TunicPortal> {
-                            new TunicPortal("Library Rotunda Lower Exit", "Library Hall", "_"),
-                            new TunicPortal("Library Rotunda Upper Exit", "Library Lab", "_"),
+                            new TunicPortal("Library Rotunda Lower Exit", "Library Hall", "_", PDir.LADDER_DOWN),
+                            new TunicPortal("Library Rotunda Upper Exit", "Library Lab", "_", PDir.LADDER_UP),
                         }
                     },
                 }
@@ -614,19 +614,19 @@ namespace TunicRandomizer {
                     {
                         "Library Lab Lower",
                         new List<TunicPortal> {
-                            new TunicPortal("Library Lab to Rotunda", "Library Rotunda", "_"),
+                            new TunicPortal("Library Lab to Rotunda", "Library Rotunda", "_", PDir.LADDER_DOWN),
                         }
                     },
                     {
                         "Library Portal",
                         new List<TunicPortal> {
-                            new TunicPortal("Library to Far Shore", "Transit", "_teleporter_library teleporter"),
+                            new TunicPortal("Library to Far Shore", "Transit", "_teleporter_library teleporter", PDir.FLOOR),
                         }
                     },
                     {
                         "Library Lab",
                         new List<TunicPortal> {
-                            new TunicPortal("Library Lab to Librarian Arena", "Library Arena", "_"),
+                            new TunicPortal("Library Lab to Librarian Arena", "Library Arena", "_", PDir.LADDER_UP),
                         }
                     },
                 }
@@ -637,7 +637,7 @@ namespace TunicRandomizer {
                     {
                         "Library Arena",
                         new List<TunicPortal> {
-                            new TunicPortal("Librarian Arena Exit", "Library Lab", "_"),
+                            new TunicPortal("Librarian Arena Exit", "Library Lab", "_", PDir.LADDER_DOWN),
                         }
                     },
                 }

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -648,19 +648,19 @@ namespace TunicRandomizer {
                     {
                         "East Forest",
                         new List<TunicPortal> {
-                            new TunicPortal("Forest to Belltower", "Forest Belltower", "_"),
-                            new TunicPortal("Forest Guard House 1 Lower Entrance", "East Forest Redux Laddercave", "_lower"),
-                            new TunicPortal("Forest Guard House 1 Gate Entrance", "East Forest Redux Laddercave", "_gate"),
-                            new TunicPortal("Forest Guard House 2 Lower Entrance", "East Forest Redux Interior", "_lower"),
-                            new TunicPortal("Forest Guard House 2 Upper Entrance", "East Forest Redux Interior", "_upper"),
-                            new TunicPortal("Forest Grave Path Lower Entrance", "Sword Access", "_lower"),
-                            new TunicPortal("Forest Grave Path Upper Entrance", "Sword Access", "_upper"),
+                            new TunicPortal("Forest to Belltower", "Forest Belltower", "_", PDir.NORTH),
+                            new TunicPortal("Forest Guard House 1 Lower Entrance", "East Forest Redux Laddercave", "_lower", PDir.NORTH),
+                            new TunicPortal("Forest Guard House 1 Gate Entrance", "East Forest Redux Laddercave", "_gate", PDir.NORTH),
+                            new TunicPortal("Forest Guard House 2 Lower Entrance", "East Forest Redux Interior", "_lower", PDir.NORTH),
+                            new TunicPortal("Forest Guard House 2 Upper Entrance", "East Forest Redux Interior", "_upper", PDir.EAST),
+                            new TunicPortal("Forest Grave Path Lower Entrance", "Sword Access", "_lower", PDir.EAST),
+                            new TunicPortal("Forest Grave Path Upper Entrance", "Sword Access", "_upper", PDir.EAST),
                         }
                     },
                     {
                         "East Forest Dance Fox Spot",
                         new List<TunicPortal> {
-                            new TunicPortal("Forest Dance Fox Outside Doorway", "East Forest Redux Laddercave", "_upper"),
+                            new TunicPortal("Forest Dance Fox Outside Doorway", "East Forest Redux Laddercave", "_upper", PDir.EAST),
                         }
                     },
                     {
@@ -677,15 +677,15 @@ namespace TunicRandomizer {
                     {
                         "Guard House 1 West",
                         new List<TunicPortal> {
-                            new TunicPortal("Guard House 1 Dance Fox Exit", "East Forest Redux", "_upper"),
-                            new TunicPortal("Guard House 1 Lower Exit", "East Forest Redux", "_lower"),
+                            new TunicPortal("Guard House 1 Dance Fox Exit", "East Forest Redux", "_upper", PDir.WEST),
+                            new TunicPortal("Guard House 1 Lower Exit", "East Forest Redux", "_lower", PDir.SOUTH),
                         }
                     },
                     {
                         "Guard House 1 East",
                         new List<TunicPortal> {
-                            new TunicPortal("Guard House 1 Upper Forest Exit", "East Forest Redux", "_gate"),
-                            new TunicPortal("Guard House 1 to Guard Captain Room", "Forest Boss Room", "_"),
+                            new TunicPortal("Guard House 1 Upper Forest Exit", "East Forest Redux", "_gate", PDir.SOUTH),
+                            new TunicPortal("Guard House 1 to Guard Captain Room", "Forest Boss Room", "_", PDir.NORTH),
                         }
                     },
                 }
@@ -696,13 +696,13 @@ namespace TunicRandomizer {
                     {
                         "Forest Grave Path Upper",
                         new List<TunicPortal> {
-                            new TunicPortal("Forest Grave Path Upper Exit", "East Forest Redux", "_upper"),
+                            new TunicPortal("Forest Grave Path Upper Exit", "East Forest Redux", "_upper", PDir.WEST),
                         }
                     },
                     {
                         "Forest Grave Path Main",
                         new List<TunicPortal> {
-                            new TunicPortal("Forest Grave Path Lower Exit", "East Forest Redux", "_lower"),
+                            new TunicPortal("Forest Grave Path Lower Exit", "East Forest Redux", "_lower", PDir.WEST),
                         }
                     },
                     {
@@ -719,8 +719,8 @@ namespace TunicRandomizer {
                     {
                         "Guard House 2",
                         new List<TunicPortal> {
-                            new TunicPortal("Guard House 2 Lower Exit", "East Forest Redux", "_lower"),
-                            new TunicPortal("Guard House 2 Upper Exit", "East Forest Redux", "_upper"),
+                            new TunicPortal("Guard House 2 Lower Exit", "East Forest Redux", "_lower", PDir.SOUTH),
+                            new TunicPortal("Guard House 2 Upper Exit", "East Forest Redux", "_upper", PDir.WEST),
                         }
                     },
                 }
@@ -731,8 +731,8 @@ namespace TunicRandomizer {
                     {
                         "Forest Boss Room",
                         new List<TunicPortal> {
-                            new TunicPortal("Guard Captain Room Non-Gate Exit", "East Forest Redux Laddercave", "_"),
-                            new TunicPortal("Guard Captain Room Gate Exit", "Forest Belltower", "_"),
+                            new TunicPortal("Guard Captain Room Non-Gate Exit", "East Forest Redux Laddercave", "_", PDir.SOUTH),
+                            new TunicPortal("Guard Captain Room Gate Exit", "Forest Belltower", "_", PDir.NORTH),
                         }
                     },
                 }
@@ -743,20 +743,20 @@ namespace TunicRandomizer {
                     {
                         "Forest Belltower Main",
                         new List<TunicPortal> {
-                            new TunicPortal("Forest Belltower to Fortress", "Fortress Courtyard", "_"),
-                            new TunicPortal("Forest Belltower to Overworld", "Overworld Redux", "_"),
+                            new TunicPortal("Forest Belltower to Fortress", "Fortress Courtyard", "_", PDir.NORTH),
+                            new TunicPortal("Forest Belltower to Overworld", "Overworld Redux", "_", PDir.WEST),
                         }
                     },
                     {
                         "Forest Belltower Lower",
                         new List<TunicPortal> {
-                            new TunicPortal("Forest Belltower to Forest", "East Forest Redux", "_"),
+                            new TunicPortal("Forest Belltower to Forest", "East Forest Redux", "_", PDir.SOUTH),
                         }
                     },
                     {
                         "Forest Belltower Upper",
                         new List<TunicPortal> {
-                            new TunicPortal("Forest Belltower to Guard Captain Room", "Forest Boss Room", "_"),
+                            new TunicPortal("Forest Belltower to Guard Captain Room", "Forest Boss Room", "_", PDir.SOUTH),
                         }
                     },
                 }
@@ -767,34 +767,34 @@ namespace TunicRandomizer {
                     {
                         "Fortress Courtyard",
                         new List<TunicPortal> {
-                            new TunicPortal("Fortress Courtyard to Fortress Grave Path Lower", "Fortress Reliquary", "_Lower"),
-                            new TunicPortal("Fortress Courtyard to Fortress Interior", "Fortress Main", "_Big Door"),
+                            new TunicPortal("Fortress Courtyard to Fortress Grave Path Lower", "Fortress Reliquary", "_Lower", PDir.EAST),
+                            new TunicPortal("Fortress Courtyard to Fortress Interior", "Fortress Main", "_Big Door", PDir.NORTH),
                         }
                     },
                     {
                         "Fortress Courtyard Upper",
                         new List<TunicPortal> {
-                            new TunicPortal("Fortress Courtyard to Fortress Grave Path Upper", "Fortress Reliquary", "_Upper"),
-                            new TunicPortal("Fortress Courtyard to East Fortress", "Fortress East", "_"),
+                            new TunicPortal("Fortress Courtyard to Fortress Grave Path Upper", "Fortress Reliquary", "_Upper", PDir.EAST),
+                            new TunicPortal("Fortress Courtyard to East Fortress", "Fortress East", "_", PDir.NORTH),
                         }
                     },
                     {
                         "Fortress Exterior near cave",
                         new List<TunicPortal> {
-                            new TunicPortal("Fortress Courtyard to Beneath the Earth", "Fortress Basement", "_"),
-                            new TunicPortal("Fortress Courtyard Shop", "Shop", "_"),
+                            new TunicPortal("Fortress Courtyard to Beneath the Earth", "Fortress Basement", "_", PDir.LADDER_DOWN),
+                            new TunicPortal("Fortress Courtyard Shop", "Shop", "_", PDir.NORTH),
                         }
                     },
                     {
                         "Fortress Exterior from East Forest",
                         new List<TunicPortal> {
-                            new TunicPortal("Fortress Courtyard to Forest Belltower", "Forest Belltower", "_"),
+                            new TunicPortal("Fortress Courtyard to Forest Belltower", "Forest Belltower", "_", PDir.SOUTH),
                         }
                     },
                     {
                         "Fortress Exterior from Overworld",
                         new List<TunicPortal> {
-                            new TunicPortal("Fortress Courtyard to Overworld", "Overworld Redux", "_"),
+                            new TunicPortal("Fortress Courtyard to Overworld", "Overworld Redux", "_", PDir.WEST),
                         }
                     },
                 }
@@ -805,13 +805,13 @@ namespace TunicRandomizer {
                     {
                         "Beneath the Vault Back",
                         new List<TunicPortal> {
-                            new TunicPortal("Beneath the Earth to Fortress Interior", "Fortress Main", "_"),
+                            new TunicPortal("Beneath the Earth to Fortress Interior", "Fortress Main", "_", PDir.EAST),
                         }
                     },
                     {
                         "Beneath the Vault Front",
                         new List<TunicPortal> {
-                            new TunicPortal("Beneath the Earth to Fortress Courtyard", "Fortress Courtyard", "_"),
+                            new TunicPortal("Beneath the Earth to Fortress Courtyard", "Fortress Courtyard", "_", PDir.LADDER_UP),
                         }
                     },
                 }

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -57,72 +57,72 @@ namespace TunicRandomizer {
                     {
                         "Overworld",
                         new List<TunicPortal> {
-                            new TunicPortal("Stick House Entrance", "Sword Cave", "_"),
-                            new TunicPortal("Windmill Entrance", "Windmill", "_"),
-                            new TunicPortal("Old House Waterfall Entrance", "Overworld Interiors", "_under_checkpoint"),
-                            new TunicPortal("Entrance to Furnace under Windmill", "Furnace", "_gyro_upper_east"),
-                            new TunicPortal("Ruined Shop Entrance", "Ruined Shop", "_"),
-                            new TunicPortal("Changing Room Entrance", "Changing Room", "_"),
-                            new TunicPortal("Cube Cave Entrance", "CubeRoom", "_"),
-                            new TunicPortal("Dark Tomb Main Entrance", "Crypt Redux", "_"),
-                            new TunicPortal("Secret Gathering Place Entrance", "Waterfall", "_"),
+                            new TunicPortal("Stick House Entrance", "Sword Cave", "_", PDir.NORTH),
+                            new TunicPortal("Windmill Entrance", "Windmill", "_", PDir.NORTH),
+                            new TunicPortal("Old House Waterfall Entrance", "Overworld Interiors", "_under_checkpoint", PDir.EAST),
+                            new TunicPortal("Entrance to Furnace under Windmill", "Furnace", "_gyro_upper_east", PDir.WEST),
+                            new TunicPortal("Ruined Shop Entrance", "Ruined Shop", "_", PDir.EAST),
+                            new TunicPortal("Changing Room Entrance", "Changing Room", "_", PDir.SOUTH),
+                            new TunicPortal("Cube Cave Entrance", "CubeRoom", "_", PDir.NORTH),
+                            new TunicPortal("Dark Tomb Main Entrance", "Crypt Redux", "_", PDir.NORTH),
+                            new TunicPortal("Secret Gathering Place Entrance", "Waterfall", "_", PDir.NORTH),
                         }
                     },
                     {
                         "East Overworld",
                         new List<TunicPortal> {
-                            new TunicPortal("Overworld to Forest Belltower", "Forest Belltower", "_"),
-                            new TunicPortal("Overworld to Fortress", "Fortress Courtyard", "_"),
+                            new TunicPortal("Overworld to Forest Belltower", "Forest Belltower", "_", PDir.EAST),
+                            new TunicPortal("Overworld to Fortress", "Fortress Courtyard", "_", PDir.EAST),
                         }
                     },
                     {
                         "Overworld at Patrol Cave",
                         new List<TunicPortal> {
-                            new TunicPortal("Patrol Cave Entrance", "PatrolCave", "_"),
+                            new TunicPortal("Patrol Cave Entrance", "PatrolCave", "_", PDir.NORTH),
                         }
                     },
                     {
                         "Upper Overworld",
                         new List<TunicPortal> {
-                            new TunicPortal("Stairs from Overworld to Mountain", "Mountain", "_"),
+                            new TunicPortal("Stairs from Overworld to Mountain", "Mountain", "_", PDir.NORTH),
                         }
                     },
                     {
                         "Overworld after Temple Rafters",
                         new List<TunicPortal> {
-                            new TunicPortal("Temple Rafters Entrance", "Temple", "_rafters"),
+                            new TunicPortal("Temple Rafters Entrance", "Temple", "_rafters", PDir.EAST),
                         }
                     },
                     {
                         "Overworld Quarry Entry",
                         new List<TunicPortal> {
-                            new TunicPortal("Overworld to Quarry Connector", "Darkwoods Tunnel", "_"),
+                            new TunicPortal("Overworld to Quarry Connector", "Darkwoods Tunnel", "_", PDir.NORTH),
                         }
                     },
                     {
                         "Overworld Beach",
                         new List<TunicPortal> {
-                            new TunicPortal("Atoll Lower Entrance", "Atoll Redux", "_lower"),
-                            new TunicPortal("Hourglass Cave Entrance", "Town Basement", "_beach"),
-                            new TunicPortal("Maze Cave Entrance", "Maze Room", "_"),
+                            new TunicPortal("Atoll Lower Entrance", "Atoll Redux", "_lower", PDir.SOUTH),
+                            new TunicPortal("Hourglass Cave Entrance", "Town Basement", "_beach", PDir.NORTH),
+                            new TunicPortal("Maze Cave Entrance", "Maze Room", "_", PDir.NORTH),
                         }
                     },
                     {
                         "Overworld Tunnel Turret",
                         new List<TunicPortal> {
-                            new TunicPortal("Entrance to Furnace from Beach", "Furnace", "_gyro_lower"),
+                            new TunicPortal("Entrance to Furnace from Beach", "Furnace", "_gyro_lower", PDir.NORTH),
                         }
                     },
                     {
                         "Overworld to Atoll Upper",
                         new List<TunicPortal> {
-                            new TunicPortal("Atoll Upper Entrance", "Atoll Redux", "_upper"),
+                            new TunicPortal("Atoll Upper Entrance", "Atoll Redux", "_upper", PDir.SOUTH),
                         }
                     },
                     {
                         "Overworld Well Ladder",
                         new List<TunicPortal> {
-                            new TunicPortal("Well Ladder Entrance", "Sewer", "_entrance"),
+                            new TunicPortal("Well Ladder Entrance", "Sewer", "_entrance", PDir.LADDER_DOWN),
                         }
                     },
                     {
@@ -141,7 +141,7 @@ namespace TunicRandomizer {
                     {
                         "Overworld to West Garden Upper",
                         new List<TunicPortal> {
-                            new TunicPortal("West Garden Entrance near Belltower", "Archipelagos Redux", "_upper"),
+                            new TunicPortal("West Garden Entrance near Belltower", "Archipelagos Redux", "_upper", PDir.WEST),
                         }
                     },
                     {
@@ -154,8 +154,8 @@ namespace TunicRandomizer {
                     {
                         "Overworld Swamp Lower Entry",
                         new List<TunicPortal> {
-                            new TunicPortal("Caustic Light Cave Entrance", "Overworld Cave", "_"),
-                            new TunicPortal("Swamp Lower Entrance", "Swamp Redux 2", "_conduit"),
+                            new TunicPortal("Caustic Light Cave Entrance", "Overworld Cave", "_", PDir.SOUTH),
+                            new TunicPortal("Swamp Lower Entrance", "Swamp Redux 2", "_conduit", PDir.SOUTH),
                         }
                     },
                     {
@@ -173,13 +173,14 @@ namespace TunicRandomizer {
                     {
                         "After Ruined Passage",
                         new List<TunicPortal> {
-                            new TunicPortal("Ruined Passage Not-Door Entrance", "Ruins Passage", "_east"),
+                            new TunicPortal("Special Shop Entrance", "ShopSpecial", "_", PDir.EAST),
+                            new TunicPortal("Ruined Passage Not-Door Entrance", "Ruins Passage", "_east", PDir.WEST),
                         }
                     },
                     {
                         "Overworld Special Shop Entry",
                         new List<TunicPortal> {
-                            new TunicPortal("Special Shop Entrance", "ShopSpecial", "_"),
+                            new TunicPortal("Special Shop Entrance", "ShopSpecial", "_", PDir.EAST),
                         }
                     },
                     {
@@ -554,9 +555,8 @@ namespace TunicRandomizer {
                     {
                         "Ruined Atoll",
                         new List<TunicPortal> {
-                            new TunicPortal("Atoll Upper Exit", "Overworld Redux", "_upper"),
-                            new TunicPortal("Atoll Shop", "Shop", "_"),
-                            new TunicPortal("Frog Stairs Eye Entrance", "Frog Stairs", "_eye"),
+                            new TunicPortal("Atoll Upper Exit", "Overworld Redux", "_upper", PDir.NORTH),
+                            new TunicPortal("Atoll Shop", "Shop", "_", PDir.NORTH),
                         }
                     },
                     {
@@ -580,7 +580,7 @@ namespace TunicRandomizer {
                     {
                         "Ruined Atoll Frog Eye",
                         new List<TunicPortal> {
-                            new TunicPortal("Frog Stairs Eye Entrance", "Frog Stairs", "_eye"),
+                            new TunicPortal("Frog Stairs Eye Entrance", "Frog Stairs", "_eye", PDir.SOUTH),  // camera rotates to be north
                         }
                     },
                     {
@@ -597,25 +597,25 @@ namespace TunicRandomizer {
                     {
                         "Frog Stairs Eye Exit",
                         new List<TunicPortal> {
-                            new TunicPortal("Frog Stairs Eye Exit", "Atoll Redux", "_eye"),
+                            new TunicPortal("Frog Stairs Eye Exit", "Atoll Redux", "_eye", PDir.NORTH),
                         }
                     },
                     {
                         "Frog Stairs Upper",
                         new List<TunicPortal> {
-                            new TunicPortal("Frog Stairs Mouth Exit", "Atoll Redux", "_mouth"),
+                            new TunicPortal("Frog Stairs Mouth Exit", "Atoll Redux", "_mouth", PDir.WEST),
                         }
                     },
                     {
                         "Frog Stairs Lower",
                         new List<TunicPortal> {
-                            new TunicPortal("Frog Stairs to Frog's Domain's Exit", "frog cave main", "_Exit"),
+                            new TunicPortal("Frog Stairs to Frog's Domain's Exit", "frog cave main", "_Exit", PDir.EAST),
                         }
                     },
                     {
                         "Frog Stairs to Frog's Domain",
                         new List<TunicPortal> {
-                            new TunicPortal("Frog Stairs to Frog's Domain's Entrance", "frog cave main", "_Entrance"),
+                            new TunicPortal("Frog Stairs to Frog's Domain's Entrance", "frog cave main", "_Entrance", PDir.LADDER_DOWN),
                         }
                     },
                 }
@@ -660,7 +660,7 @@ namespace TunicRandomizer {
                     {
                         "Library Hall Bookshelf",
                         new List<TunicPortal> {
-                            new TunicPortal("Library Hall Bookshelf Exit", "Library Exterior", "_"),
+                            new TunicPortal("Library Hall Bookshelf Exit", "Library Exterior", "_", PDir.EAST),
                         }
                     },
                     {
@@ -672,7 +672,7 @@ namespace TunicRandomizer {
                     {
                         "Library Hall to Rotunda",
                         new List<TunicPortal> {
-                            new TunicPortal("Library Hall to Rotunda", "Library Rotunda", "_"),
+                            new TunicPortal("Library Hall to Rotunda", "Library Rotunda", "_", PDir.LADDER_UP),
                         }
                     },
                 }
@@ -683,13 +683,13 @@ namespace TunicRandomizer {
                     {
                         "Library Rotunda to Hall",
                         new List<TunicPortal> {
-                            new TunicPortal("Library Rotunda Lower Exit", "Library Hall", "_"),
+                            new TunicPortal("Library Rotunda Lower Exit", "Library Hall", "_", PDir.LADDER_DOWN),
                         }
                     },
                     {
                         "Library Rotunda to Lab",
                         new List<TunicPortal> {
-                            new TunicPortal("Library Rotunda Upper Exit", "Library Lab", "_"),
+                            new TunicPortal("Library Rotunda Upper Exit", "Library Lab", "_", PDir.LADDER_UP),
                         }
                     },
                 }
@@ -734,12 +734,12 @@ namespace TunicRandomizer {
                     {
                         "East Forest",
                         new List<TunicPortal> {
-                            new TunicPortal("Forest to Belltower", "Forest Belltower", "_"),
-                            new TunicPortal("Forest Guard House 1 Lower Entrance", "East Forest Redux Laddercave", "_lower"),
-                            new TunicPortal("Forest Guard House 1 Gate Entrance", "East Forest Redux Laddercave", "_gate"),
-                            new TunicPortal("Forest Guard House 2 Upper Entrance", "East Forest Redux Interior", "_upper"),
-                            new TunicPortal("Forest Grave Path Lower Entrance", "Sword Access", "_lower"),
-                            new TunicPortal("Forest Grave Path Upper Entrance", "Sword Access", "_upper"),
+                            new TunicPortal("Forest to Belltower", "Forest Belltower", "_", PDir.NORTH),
+                            new TunicPortal("Forest Guard House 1 Lower Entrance", "East Forest Redux Laddercave", "_lower", PDir.NORTH),
+                            new TunicPortal("Forest Guard House 1 Gate Entrance", "East Forest Redux Laddercave", "_gate", PDir.NORTH),
+                            new TunicPortal("Forest Guard House 2 Upper Entrance", "East Forest Redux Interior", "_upper", PDir.EAST),
+                            new TunicPortal("Forest Grave Path Lower Entrance", "Sword Access", "_lower", PDir.EAST),
+                            new TunicPortal("Forest Grave Path Upper Entrance", "Sword Access", "_upper", PDir.EAST),
                         }
                     },
                     {
@@ -757,7 +757,7 @@ namespace TunicRandomizer {
                     {
                         "Lower Forest",
                         new List<TunicPortal> {
-                            new TunicPortal("Forest Guard House 2 Lower Entrance", "East Forest Redux Interior", "_lower"),
+                            new TunicPortal("Forest Guard House 2 Lower Entrance", "East Forest Redux Interior", "_lower", PDir.NORTH),
                         }
                     },
                 }
@@ -810,13 +810,13 @@ namespace TunicRandomizer {
                     {
                         "Guard House 2 Upper",
                         new List<TunicPortal> {
-                            new TunicPortal("Guard House 2 Upper Exit", "East Forest Redux", "_upper"),
+                            new TunicPortal("Guard House 2 Upper Exit", "East Forest Redux", "_upper", PDir.WEST),
                         }
                     },
                     {
                         "Guard House 2 Lower",
                         new List<TunicPortal> {
-                            new TunicPortal("Guard House 2 Lower Exit", "East Forest Redux", "_lower"),
+                            new TunicPortal("Guard House 2 Lower Exit", "East Forest Redux", "_lower", PDir.SOUTH),
                         }
                     },
                 }
@@ -877,13 +877,13 @@ namespace TunicRandomizer {
                     {
                         "Fortress Exterior near cave",
                         new List<TunicPortal> {
-                            new TunicPortal("Fortress Courtyard Shop", "Shop", "_"),
+                            new TunicPortal("Fortress Courtyard Shop", "Shop", "_", PDir.NORTH),
                         }
                     },
                     {
                         "Beneath the Vault Entry",
                         new List<TunicPortal> {
-                            new TunicPortal("Fortress Courtyard to Beneath the Earth", "Fortress Basement", "_"),
+                            new TunicPortal("Fortress Courtyard to Beneath the Earth", "Fortress Basement", "_", PDir.LADDER_DOWN),
                         }
                     },
                     {
@@ -1020,7 +1020,7 @@ namespace TunicRandomizer {
                     {
                         "Lower Mountain",
                         new List<TunicPortal> {
-                            new TunicPortal("Mountain to Quarry", "Quarry Redux", "_", PDir.NORTH),  // camera rotates to look west
+                            new TunicPortal("Mountain to Quarry", "Quarry Redux", "_", PDir.SOUTH),  // starts north, rotates to be east, but the connecting one is north so it's south
                             new TunicPortal("Mountain to Overworld", "Overworld Redux", "_", PDir.SOUTH),
                         }
                     },
@@ -1043,8 +1043,8 @@ namespace TunicRandomizer {
                     {
                         "Quarry Connector",
                         new List<TunicPortal> {
-                            new TunicPortal("Quarry Connector to Overworld", "Overworld Redux", "_"),
-                            new TunicPortal("Quarry Connector to Quarry", "Quarry Redux", "_"),
+                            new TunicPortal("Quarry Connector to Overworld", "Overworld Redux", "_", PDir.NORTH),  // rotates, but the connecting is south
+                            new TunicPortal("Quarry Connector to Quarry", "Quarry Redux", "_", PDir.SOUTH),
                         }
                     },
                 }
@@ -1055,7 +1055,7 @@ namespace TunicRandomizer {
                     {
                         "Quarry Entry",
                         new List<TunicPortal> {
-                            new TunicPortal("Quarry to Overworld Exit", "Darkwoods Tunnel", "_"),
+                            new TunicPortal("Quarry to Overworld Exit", "Darkwoods Tunnel", "_", PDir.SOUTH),
                             new TunicPortal("Quarry Shop", "Shop", "_", PDir.NORTH),
                         }
                     },
@@ -1132,13 +1132,13 @@ namespace TunicRandomizer {
                     {
                         "Rooted Ziggurat Upper Entry",
                         new List<TunicPortal> {
-                            new TunicPortal("Ziggurat Upper to Ziggurat Entry Hallway", "ziggurat2020_0", "_"),
+                            new TunicPortal("Ziggurat Upper to Ziggurat Entry Hallway", "ziggurat2020_0", "_", PDir.SOUTH),
                         }
                     },
                     {
                         "Rooted Ziggurat Upper Back",
                         new List<TunicPortal> {
-                            new TunicPortal("Ziggurat Upper to Ziggurat Tower", "ziggurat2020_2", "_"),
+                            new TunicPortal("Ziggurat Upper to Ziggurat Tower", "ziggurat2020_2", "_", PDir.NORTH),  // lots of rotation, connecting is south
                         }
                     },
                 }
@@ -1172,7 +1172,7 @@ namespace TunicRandomizer {
                     {
                         "Rooted Ziggurat Portal Room Entrance",
                         new List<TunicPortal> {
-                            new TunicPortal("Ziggurat Portal Room Entrance", "ziggurat2020_FTRoom", "_", PDir.NORTH),  // Camera rotates, but this probably doesn't need special handling
+                            new TunicPortal("Ziggurat Portal Room Entrance", "ziggurat2020_FTRoom", "_", PDir.NORTH),
                         }
                     },
                     {
@@ -1219,7 +1219,7 @@ namespace TunicRandomizer {
                     {
                         "Swamp to Cathedral Treasure Room",
                         new List<TunicPortal> {
-                            new TunicPortal("Swamp to Cathedral Secret Legend Room Entrance", "Cathedral Redux", "_secret", PDir.SOUTH),  // double check
+                            new TunicPortal("Swamp to Cathedral Secret Legend Room Entrance", "Cathedral Redux", "_secret", PDir.SOUTH),
                         }
                     },
                     {

--- a/src/Patches/TunicPortals.cs
+++ b/src/Patches/TunicPortals.cs
@@ -173,7 +173,6 @@ namespace TunicRandomizer {
                     {
                         "After Ruined Passage",
                         new List<TunicPortal> {
-                            new TunicPortal("Special Shop Entrance", "ShopSpecial", "_", PDir.EAST),
                             new TunicPortal("Ruined Passage Not-Door Entrance", "Ruins Passage", "_east", PDir.WEST),
                         }
                     },
@@ -251,7 +250,7 @@ namespace TunicRandomizer {
                         "Old House Front",
                         new List<TunicPortal> {
                             new TunicPortal("Old House Door Exit", "Overworld Redux", "_house", PDir.WEST),
-                            new TunicPortal("Old House to Glyph Tower", "g_elements", "_", PDir.FLOOR),
+                            new TunicPortal("Old House to Glyph Tower", "g_elements", "_", PDir.SOUTH),  // weird case, going off of the connecting
                         }
                     },
                     {


### PR DESCRIPTION
Just purely adds another attribute to the portals to designate which direction they are. Might use this later, might not, but I already regretted not merging this in to the previous PR, so I don't want another messy merge conflict later.