### PR TITLE
Make it so the setting string doesn't automatically copy to your clipboard on new game

### DIFF
--- a/src/Data/RandomizerSettings.cs
+++ b/src/Data/RandomizerSettings.cs
@@ -418,7 +418,6 @@ namespace TunicRandomizer {
                 QuickSettings.CustomSeed = seed;
             }
             string SettingsString = $"tunc:{PluginInfo.VERSION}:{seed}:{EncodedSettings}";
-            GUIUtility.systemCopyBuffer = SettingsString;
             return SettingsString;
         }
 

--- a/src/Patches/QuickSettings.cs
+++ b/src/Patches/QuickSettings.cs
@@ -321,7 +321,7 @@ namespace TunicRandomizer {
             y += 40f;
             bool CopySettings = GUI.Button(new Rect(10f, y, 200f, 30f), "Copy Seed + Settings");
             if (CopySettings) {
-                TunicRandomizer.Settings.GetSettingsString();
+                GUIUtility.systemCopyBuffer = TunicRandomizer.Settings.GetSettingsString();
             }
             bool PasteSettings = GUI.Button(new Rect(220f, y, 200f, 30f), "Paste Seed + Settings");
             if (PasteSettings) {


### PR DESCRIPTION
Moves the copy thing to only happen when you click on copy seed and settings.