### PR TITLE
Modifications to the ladders branch

### DIFF
--- a/src/Archipelago/ArchipelagoIntegration.cs
+++ b/src/Archipelago/ArchipelagoIntegration.cs
@@ -39,6 +39,7 @@ namespace TunicRandomizer {
         public bool sentRelease = false;
         public bool sentCollect = false;
         public int ItemIndex = 0;
+        public Dictionary<string, int> startInventoryItems;
 
         public void Update() {
             if ((SceneManager.GetActiveScene().name == "TitleScreen" && TunicRandomizer.Settings.Mode != RandomizerSettings.RandomizerType.ARCHIPELAGO) || SaveFile.GetInt("archipelago") == 0) {
@@ -126,6 +127,14 @@ namespace TunicRandomizer {
                 }
 
                 SetupDataStorage();
+
+                // start inventory items have a location ID of -2, add them to a dict so we can use them for first steps
+                foreach (NetworkItem item in session.Items.AllItemsReceived) {
+                    if (item.Location == -2) {
+                        string itemName = session.Items.GetItemName(item.Item);
+                        ItemRandomizer.AddStringToDict(startInventoryItems, itemName);
+                    }
+                }
 
             } else {
                 LoginFailure loginFailure = (LoginFailure)LoginResult;

--- a/src/Archipelago/ArchipelagoIntegration.cs
+++ b/src/Archipelago/ArchipelagoIntegration.cs
@@ -39,7 +39,6 @@ namespace TunicRandomizer {
         public bool sentRelease = false;
         public bool sentCollect = false;
         public int ItemIndex = 0;
-        public Dictionary<string, int> startInventoryItems;
 
         public void Update() {
             if ((SceneManager.GetActiveScene().name == "TitleScreen" && TunicRandomizer.Settings.Mode != RandomizerSettings.RandomizerType.ARCHIPELAGO) || SaveFile.GetInt("archipelago") == 0) {
@@ -132,7 +131,30 @@ namespace TunicRandomizer {
                 foreach (NetworkItem item in session.Items.AllItemsReceived) {
                     if (item.Location == -2) {
                         string itemName = session.Items.GetItemName(item.Item);
-                        ItemRandomizer.AddStringToDict(startInventoryItems, itemName);
+                        if (itemName == "Magic Wand") {
+                            itemName = "Techbow";
+                        } else if (itemName == "Magic Dagger") {
+                            itemName = "Stundagger";
+                        } else if (itemName == "Magic Orb") {
+                            itemName = "Wand";
+                        } else if (itemName == "Hero's Laurels") {
+                            itemName = "Hyperdash";
+                        } else if (itemName == "Old House Key") {
+                            itemName = "Key (House)";
+                        } else if (itemName == "Fortress Vault Key") {
+                            itemName = "Vault Key (Red)";
+                        } else if (itemName == "Scavenger Mask") {
+                            itemName = "Mask";
+                        } else if (itemName == "Golden Coin") {
+                            itemName = "Trinket Coin";
+                        } else if (itemName == "Pages 24-25 (Prayer)") {
+                            itemName = "12";
+                        } else if (itemName == "Pages 42-43 (Holy Cross)") {
+                            itemName = "21";
+                        } else if (itemName == "Pages 52-53 (Icebolt)") {
+                            itemName = "26";
+                        }
+                        ItemRandomizer.AddStringToDict(Hints.StartInventoryItems, itemName);
                     }
                 }
 

--- a/src/Archipelago/ArchipelagoIntegration.cs
+++ b/src/Archipelago/ArchipelagoIntegration.cs
@@ -132,8 +132,7 @@ namespace TunicRandomizer {
                     if (item.Location == -2) {
                         string itemName = session.Items.GetItemName(item.Item);
                         if (ItemLookup.Items.ContainsKey(itemName)) {
-                                                   ItemRandomizer.AddStringToDict(Hints.StartInventoryItems, 
-ItemLookup.Items[itemName].ItemNameForInventory);
+                            ItemRandomizer.AddStringToDict(Hints.StartInventoryItems, ItemLookup.Items[itemName].ItemNameForInventory);
                         }
                     }
                 }

--- a/src/Archipelago/ArchipelagoIntegration.cs
+++ b/src/Archipelago/ArchipelagoIntegration.cs
@@ -132,9 +132,9 @@ namespace TunicRandomizer {
                     if (item.Location == -2) {
                         string itemName = session.Items.GetItemName(item.Item);
                         if (ItemLookup.Items.ContainsKey(itemName)) {
-                            itemName = ItemLookup.Items[itemName].ItemNameForInventory;
+                                                   ItemRandomizer.AddStringToDict(Hints.StartInventoryItems, 
+ItemLookup.Items[itemName].ItemNameForInventory);
                         }
-                        ItemRandomizer.AddStringToDict(Hints.StartInventoryItems, itemName);
                     }
                 }
 

--- a/src/Archipelago/ArchipelagoIntegration.cs
+++ b/src/Archipelago/ArchipelagoIntegration.cs
@@ -131,28 +131,8 @@ namespace TunicRandomizer {
                 foreach (NetworkItem item in session.Items.AllItemsReceived) {
                     if (item.Location == -2) {
                         string itemName = session.Items.GetItemName(item.Item);
-                        if (itemName == "Magic Wand") {
-                            itemName = "Techbow";
-                        } else if (itemName == "Magic Dagger") {
-                            itemName = "Stundagger";
-                        } else if (itemName == "Magic Orb") {
-                            itemName = "Wand";
-                        } else if (itemName == "Hero's Laurels") {
-                            itemName = "Hyperdash";
-                        } else if (itemName == "Old House Key") {
-                            itemName = "Key (House)";
-                        } else if (itemName == "Fortress Vault Key") {
-                            itemName = "Vault Key (Red)";
-                        } else if (itemName == "Scavenger Mask") {
-                            itemName = "Mask";
-                        } else if (itemName == "Golden Coin") {
-                            itemName = "Trinket Coin";
-                        } else if (itemName == "Pages 24-25 (Prayer)") {
-                            itemName = "12";
-                        } else if (itemName == "Pages 42-43 (Holy Cross)") {
-                            itemName = "21";
-                        } else if (itemName == "Pages 52-53 (Icebolt)") {
-                            itemName = "26";
+                        if (ItemLookup.Items.ContainsKey(itemName)) {
+                            itemName = ItemLookup.Items[itemName].ItemNameForInventory;
                         }
                         ItemRandomizer.AddStringToDict(Hints.StartInventoryItems, itemName);
                     }

--- a/src/Data/Hints.cs
+++ b/src/Data/Hints.cs
@@ -399,10 +399,6 @@ namespace TunicRandomizer {
             } else {
                 ItemRandomizer.SphereZero = ItemRandomizer.GetSphereOne(StartingInventory);
             }
-            Logger.LogInfo("test message 2");
-            foreach (string item in ItemRandomizer.SphereZero.Keys) {
-                Logger.LogInfo(item);
-            }
             foreach (string itemkey in ItemLookup.ItemList.Keys) {
                 ArchipelagoItem item = ItemLookup.ItemList[itemkey];
                 if (Archipelago.instance.IsTunicPlayer(item.Player) && MailboxItems.Contains(item.ItemName)) {

--- a/src/Data/Hints.cs
+++ b/src/Data/Hints.cs
@@ -383,6 +383,8 @@ namespace TunicRandomizer {
             Dictionary<string, ArchipelagoItem> SphereOnePlayer = new Dictionary<string, ArchipelagoItem>();
             Dictionary<string, ArchipelagoItem> SphereOneOthersTunic = new Dictionary<string, ArchipelagoItem>();
             Dictionary<string, ArchipelagoItem> SphereOneOthers = new Dictionary<string, ArchipelagoItem>();
+            ItemRandomizer.PopulatePrecollected();
+            // todo: make this instead look at start inventory, which always has a location ID of -2
             List<string> ERSphereOneItemsAndAreas = ItemRandomizer.GetERSphereOne();
             foreach (string itemkey in ItemLookup.ItemList.Keys) {
                 ArchipelagoItem item = ItemLookup.ItemList[itemkey];

--- a/src/Data/Hints.cs
+++ b/src/Data/Hints.cs
@@ -393,11 +393,11 @@ namespace TunicRandomizer {
             ItemRandomizer.PopulatePrecollected();
             TunicPortals.VanillaPortals();
             // StartInventoryItems is populated with your start inventory items, which are items with a location ID of -2
-            Dictionary<string, int> StartingInventory = ItemRandomizer.AddListToDict(StartInventoryItems, ItemRandomizer.PrecollectedItems);
+            Dictionary<string, int> StartInventoryAndPrecollected = ItemRandomizer.AddListToDict(StartInventoryItems, ItemRandomizer.PrecollectedItems);
             if (SaveFile.GetInt(EntranceRando) == 1) {
-                ItemRandomizer.SphereZero = ItemRandomizer.GetERSphereOne(StartingInventory);
+                ItemRandomizer.SphereZero = ItemRandomizer.GetERSphereOne(StartInventoryAndPrecollected);
             } else {
-                ItemRandomizer.SphereZero = ItemRandomizer.GetSphereOne(StartingInventory);
+                ItemRandomizer.SphereZero = ItemRandomizer.GetSphereOne(StartInventoryAndPrecollected);
             }
             foreach (string itemkey in ItemLookup.ItemList.Keys) {
                 ArchipelagoItem item = ItemLookup.ItemList[itemkey];

--- a/src/Data/Hints.cs
+++ b/src/Data/Hints.cs
@@ -391,12 +391,17 @@ namespace TunicRandomizer {
             Dictionary<string, ArchipelagoItem> SphereOneOthersTunic = new Dictionary<string, ArchipelagoItem>();
             Dictionary<string, ArchipelagoItem> SphereOneOthers = new Dictionary<string, ArchipelagoItem>();
             ItemRandomizer.PopulatePrecollected();
+            TunicPortals.VanillaPortals();
             // StartInventoryItems is populated with your start inventory items, which are items with a location ID of -2
             Dictionary<string, int> StartingInventory = ItemRandomizer.AddListToDict(StartInventoryItems, ItemRandomizer.PrecollectedItems);
             if (SaveFile.GetInt(EntranceRando) == 1) {
                 ItemRandomizer.SphereZero = ItemRandomizer.GetERSphereOne(StartingInventory);
             } else {
                 ItemRandomizer.SphereZero = ItemRandomizer.GetSphereOne(StartingInventory);
+            }
+            Logger.LogInfo("test message 2");
+            foreach (string item in ItemRandomizer.SphereZero.Keys) {
+                Logger.LogInfo(item);
             }
             foreach (string itemkey in ItemLookup.ItemList.Keys) {
                 ArchipelagoItem item = ItemLookup.ItemList[itemkey];

--- a/src/Data/Hints.cs
+++ b/src/Data/Hints.cs
@@ -61,6 +61,7 @@ namespace TunicRandomizer {
         public static Dictionary<string, HeroGraveHint> HeroGraveHints = new Dictionary<string, HeroGraveHint>();
 
         public static Dictionary<string, string> HintMessages = new Dictionary<string, string>();
+        public static Dictionary<string, int> StartInventoryItems = new Dictionary<string, int>();
 
         public static void PopulateHints() {
             HintMessages.Clear();
@@ -389,11 +390,12 @@ namespace TunicRandomizer {
             Dictionary<string, ArchipelagoItem> SphereOneOthersTunic = new Dictionary<string, ArchipelagoItem>();
             Dictionary<string, ArchipelagoItem> SphereOneOthers = new Dictionary<string, ArchipelagoItem>();
             ItemRandomizer.PopulatePrecollected();
+            Dictionary<string, int> StartingInventory = ItemRandomizer.AddListToDict(StartInventoryItems, ItemRandomizer.PrecollectedItems);
             // todo: make this instead look at start inventory, which always has a location ID of -2
             if (SaveFile.GetInt(EntranceRando) == 1) {
-                ItemRandomizer.SphereZero = ItemRandomizer.GetERSphereOne();
+                ItemRandomizer.SphereZero = ItemRandomizer.GetERSphereOne(StartingInventory);
             } else {
-                ItemRandomizer.SphereZero = ItemRandomizer.GetSphereOne();
+                ItemRandomizer.SphereZero = ItemRandomizer.GetSphereOne(StartingInventory);
             }
             foreach (string itemkey in ItemLookup.ItemList.Keys) {
                 ArchipelagoItem item = ItemLookup.ItemList[itemkey];

--- a/src/Data/Hints.cs
+++ b/src/Data/Hints.cs
@@ -61,6 +61,7 @@ namespace TunicRandomizer {
         public static Dictionary<string, HeroGraveHint> HeroGraveHints = new Dictionary<string, HeroGraveHint>();
 
         public static Dictionary<string, string> HintMessages = new Dictionary<string, string>();
+        // StartInventoryItems are the items in your Archipelago start inventory
         public static Dictionary<string, int> StartInventoryItems = new Dictionary<string, int>();
 
         public static void PopulateHints() {

--- a/src/Data/Hints.cs
+++ b/src/Data/Hints.cs
@@ -308,6 +308,9 @@ namespace TunicRandomizer {
                 MailboxItems.Add("12");
                 MailboxItems.Add("21");
             }
+            if (SaveFile.GetInt(SaveFlags.LadderRandoEnabled) == 1) {
+                MailboxItems.AddRange(new List<string> { "Ladders in Overworld Town", "Ladders near Weathervane", "Ladders near Overworld Checkpoint", "Ladders in Well", "Ladder to Swamp" });
+            }
             List<Check> mailboxHintables = new List<Check>();
             foreach (string Item in MailboxItems) {
                 mailboxHintables.AddRange(ItemRandomizer.FindAllRandomizedItemsByName(Item));

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -523,10 +523,14 @@ namespace TunicRandomizer {
         }
 
         // in non-ER, we want the actual sphere 1
-        public static Dictionary<string, int> GetSphereOne() {
+        public static Dictionary<string, int> GetSphereOne(Dictionary<string, int> startInventory = null) {
             Dictionary<string, int> Inventory = new Dictionary<string, int>() { { "Overworld", 1 } };
 
-            Inventory = AddListToDict(Inventory, PrecollectedItems);
+            if (startInventory == null) {
+                Inventory = AddListToDict(Inventory, PrecollectedItems);
+            } else {
+                Inventory = startInventory;
+            }
 
             while (true) {
                 int start_num = Inventory.Count;
@@ -543,12 +547,16 @@ namespace TunicRandomizer {
         }
 
         // In ER, we want sphere 1 to be in Overworld or adjacent to Overworld
-        public static Dictionary<string, int> GetERSphereOne() {
+        public static Dictionary<string, int> GetERSphereOne(Dictionary<string, int> startInventory = null) {
             List<Portal> PortalInventory = new List<Portal>();
             Dictionary<string, int> CombinedInventory = new Dictionary<string, int>() { { "Overworld", 1 } };
 
-            CombinedInventory = AddListToDict(CombinedInventory, PrecollectedItems);
-
+            if (startInventory == null) {
+                CombinedInventory = AddListToDict(CombinedInventory, PrecollectedItems);
+            } else {
+                CombinedInventory = startInventory;
+            }
+            
             CombinedInventory = TunicPortals.FirstStepsUpdateReachableRegions(CombinedInventory);
             
             // find which portals you can reach from spawn without additional progression

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -259,7 +259,7 @@ namespace TunicRandomizer {
                 foreach (KeyValuePair<string, int> unplacedItem in UnplacedInventory) {
                     FullInventory.Add(unplacedItem.Key, unplacedItem.Value);
                 }
-                FullInventory = AddListToDict(FullInventory, PrecollectedItems);
+                AddListToDict(FullInventory, PrecollectedItems);
                     
                 // fill up our FullInventory with regions until we stop getting new regions -- these are the regions we can currently access
                 while (true) {
@@ -292,7 +292,7 @@ namespace TunicRandomizer {
                         testFullInventory.Add(testUnplacedItem.Key, testUnplacedItem.Value);
                     }
 
-                    testFullInventory = AddListToDict(testFullInventory, PrecollectedItems);
+                    AddListToDict(testFullInventory, PrecollectedItems);
 
                     if (SaveFile.GetInt("randomizer entrance rando enabled") == 1) {
                         // this should keep looping until every portal either doesn't give a reward, or has already given its reward
@@ -302,7 +302,7 @@ namespace TunicRandomizer {
                         foreach (KeyValuePair<string, int> unplacedItem in testUnplacedInventory) {
                             testFullInventory.Add(unplacedItem.Key, unplacedItem.Value);
                         }
-                        testFullInventory = AddListToDict(testFullInventory, PrecollectedItems);
+                        AddListToDict(testFullInventory, PrecollectedItems);
 
                         // fill up our FullInventory with regions until we stop getting new regions -- these are the portals and regions we can currently reach
                         while (true) {
@@ -357,7 +357,7 @@ namespace TunicRandomizer {
 
             if (SaveFile.GetInt("randomizer entrance rando enabled") == 1) {
                 SphereZero.Clear();
-                SphereZero = AddDictToDict(SphereZero, GetERSphereOne());
+                AddDictToDict(SphereZero, GetERSphereOne());
             }
 
             // shuffle remaining rewards and locations
@@ -527,9 +527,9 @@ namespace TunicRandomizer {
             Dictionary<string, int> Inventory = new Dictionary<string, int>() { { "Overworld", 1 } };
 
             if (startInventory == null) {
-                Inventory = AddListToDict(Inventory, PrecollectedItems);
+                AddListToDict(Inventory, PrecollectedItems);
             } else {
-                Inventory = AddDictToDict(Inventory, startInventory);
+                AddDictToDict(Inventory, startInventory);
             }
 
             while (true) {
@@ -552,9 +552,9 @@ namespace TunicRandomizer {
             Dictionary<string, int> Inventory = new Dictionary<string, int>() { { "Overworld", 1 } };
 
             if (startInventory == null) {
-                Inventory = AddListToDict(Inventory, PrecollectedItems);
+                AddListToDict(Inventory, PrecollectedItems);
             } else {
-                Inventory = AddDictToDict(Inventory, startInventory);
+                AddDictToDict(Inventory, startInventory);
             }
             
             Inventory = TunicPortals.FirstStepsUpdateReachableRegions(Inventory);

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -529,7 +529,7 @@ namespace TunicRandomizer {
             if (startInventory == null) {
                 Inventory = AddListToDict(Inventory, PrecollectedItems);
             } else {
-                Inventory = startInventory;
+                Inventory = AddDictToDict(Inventory, startInventory);
             }
 
             while (true) {
@@ -549,34 +549,34 @@ namespace TunicRandomizer {
         // In ER, we want sphere 1 to be in Overworld or adjacent to Overworld
         public static Dictionary<string, int> GetERSphereOne(Dictionary<string, int> startInventory = null) {
             List<Portal> PortalInventory = new List<Portal>();
-            Dictionary<string, int> CombinedInventory = new Dictionary<string, int>() { { "Overworld", 1 } };
+            Dictionary<string, int> Inventory = new Dictionary<string, int>() { { "Overworld", 1 } };
 
             if (startInventory == null) {
-                CombinedInventory = AddListToDict(CombinedInventory, PrecollectedItems);
+                Inventory = AddListToDict(Inventory, PrecollectedItems);
             } else {
-                CombinedInventory = startInventory;
+                Inventory = AddDictToDict(Inventory, startInventory);
             }
             
-            CombinedInventory = TunicPortals.FirstStepsUpdateReachableRegions(CombinedInventory);
+            Inventory = TunicPortals.FirstStepsUpdateReachableRegions(Inventory);
             
             // find which portals you can reach from spawn without additional progression
             foreach (PortalCombo portalCombo in TunicPortals.RandomizedPortals.Values) {
-                if (CombinedInventory.ContainsKey(portalCombo.Portal1.Region)) {
+                if (Inventory.ContainsKey(portalCombo.Portal1.Region)) {
                     PortalInventory.Add(portalCombo.Portal2);
                 }
-                if (CombinedInventory.ContainsKey(portalCombo.Portal2.Region)) {
+                if (Inventory.ContainsKey(portalCombo.Portal2.Region)) {
                     PortalInventory.Add(portalCombo.Portal1);
                 }
             }
 
             // add the regions you can reach as your first steps to the inventory
             foreach (Portal portal in PortalInventory) {
-                if (!CombinedInventory.ContainsKey(portal.Region)) {
-                    CombinedInventory.Add(portal.Region, 1);
+                if (!Inventory.ContainsKey(portal.Region)) {
+                    Inventory.Add(portal.Region, 1);
                 }
             }
-            CombinedInventory = TunicPortals.FirstStepsUpdateReachableRegions(CombinedInventory);
-            return CombinedInventory;
+            Inventory = TunicPortals.FirstStepsUpdateReachableRegions(Inventory);
+            return Inventory;
         }
     }
 }

--- a/src/Patches/PlayerCharacterPatches.cs
+++ b/src/Patches/PlayerCharacterPatches.cs
@@ -431,7 +431,7 @@ namespace TunicRandomizer {
             TunicRandomizer.Tracker = new ItemTracker();
             TunicRandomizer.Tracker.Seed = seed;
             Logger.LogInfo("Loading single player seed: " + seed);
-            ItemRandomizer.PopulateSphereZero();
+            ItemRandomizer.PopulatePrecollected();
             ItemRandomizer.RandomizeAndPlaceItems();
         }
 


### PR DESCRIPTION
- Allow ladders to be part of first steps items in single player ladder shuffle (if/until you remove first steps from ladder shuffle)
- Properly separate `SphereZero` and `PrecollectedItems` from each other.
  - `PrecollectedItems` just contains items you're assumed to have (sword if start with sword is on, ladders if ladder shuffle is off, abilities if ability shuffle is off, lantern/mask if lanternless/maskless are on).
  - `SphereZero` will only be populated at the end of gen, and will contain your `PrecollectedItems` as well as the regions you can access with only those items.
- Actually add the ladders to `ProgressionNames` if ladder shuffle is on, which is probably the actual reason why we were getting that hang from "too few places to place items" -- it was likely assuming you had no ladders throughout the entire gen, and only placing items in locations accessible with other items. It could still probably hang, but should be much, much rarer.
- Clean up a bunch of things that were commented out, and deduplicate a few things.
- Use `AddListToDict` in a few more spots where it can be used.
- FIxed(?) the mailbox hints. Idk, it's late, I didn't test it really.
- Made it so the mailbox hint in AP takes start inventory into account.