### PR TITLE
Implement enemy toggles for the enemy randomizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ With the exception of the Logic settings (which are determined in your Archipela
   - Enemies are randomized based on the difficulty of the original enemy being swapped out.
 - Seeded Enemies
   - Enemy spawns will remain consistent everytime an area is reloaded.
+- Enemy Toggles
+  - Allows you to customize the enemy randomizer experience by choosing which enemies you want to appear.
+  - Turn on the `Use Enemy Toggles` option and then use the Enemy Toggle List to make your choices.
 ### Fox Customization 🦊
 - Random Fox Colors
   - Fox colors will randomize on every load/scene transition.

--- a/src/Data/RandomizerSettings.cs
+++ b/src/Data/RandomizerSettings.cs
@@ -266,7 +266,7 @@ namespace TunicRandomizer {
             set;
         }
 
-        public Dictionary<string, bool> ExcludedEnemyList {
+        public Dictionary<string, bool> EnemyToggles {
             get;
             set;
         }
@@ -401,9 +401,9 @@ namespace TunicRandomizer {
             SeededEnemies = true;
             ExtraEnemiesEnabled = false;
             ExcludeEnemies = false;
-            ExcludedEnemyList = new Dictionary<string, bool>();
-            foreach(string enemy in EnemyRandomizer.ProperEnemyNames.Keys) {
-                ExcludedEnemyList.Add(enemy, false);
+            EnemyToggles = new Dictionary<string, bool>();
+            foreach(string enemy in EnemyRandomizer.EnemyToggleOptionNames.Values) {
+                EnemyToggles.Add(enemy, true);
             }
 
             // Race Settings

--- a/src/Data/RandomizerSettings.cs
+++ b/src/Data/RandomizerSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
@@ -239,6 +240,7 @@ namespace TunicRandomizer {
         private const int EXTRA_ENEMIES = 2;
         private const int BALANCED_ENEMIES = 4;
         private const int SEEDED_ENEMIES = 8;
+        private const int EXCLUDE_ENEMIES = 16;
         public bool EnemyRandomizerEnabled {
             get;
             set;
@@ -255,6 +257,16 @@ namespace TunicRandomizer {
         }
 
         public bool SeededEnemies {
+            get;
+            set;
+        }
+
+        public bool ExcludeEnemies {
+            get;
+            set;
+        }
+
+        public Dictionary<string, bool> ExcludedEnemyList {
             get;
             set;
         }
@@ -388,6 +400,11 @@ namespace TunicRandomizer {
             BalancedEnemies = true;
             SeededEnemies = true;
             ExtraEnemiesEnabled = false;
+            ExcludeEnemies = false;
+            ExcludedEnemyList = new Dictionary<string, bool>();
+            foreach(string enemy in EnemyRandomizer.ProperEnemyNames.Keys) {
+                ExcludedEnemyList.Add(enemy, false);
+            }
 
             // Race Settings
             RaceMode = false;
@@ -493,6 +510,7 @@ namespace TunicRandomizer {
                 ExtraEnemiesEnabled = eval(enemies, EXTRA_ENEMIES);
                 BalancedEnemies = eval(enemies, BALANCED_ENEMIES);
                 SeededEnemies = eval(enemies, SEEDED_ENEMIES);
+                ExcludeEnemies = eval(enemies, EXCLUDE_ENEMIES);
 
                 int race = int.Parse(decodedSplit[8]);
                 RaceMode = eval(race, RACE_MODE);

--- a/src/Patches/EnemyRandomizer.cs
+++ b/src/Patches/EnemyRandomizer.cs
@@ -384,94 +384,70 @@ namespace TunicRandomizer {
             { "Blob", $"Blob" },
             { "BlobBig", $"Big Blob" },
             { "BlobBigger", $"Bigger Blob" },
-
             { "Hedgehog", $"Hedgehog" },
             { "HedgehogBig", $"Big Hedgehog" },
-
             { "Skuladot redux", $"Rudeling" },
-            { "Skuladot redux void", $"Rudeling (Void)" },
             { "Skuladot redux_ghost", $"Rudeling (Ghost)" },
+            { "Skuladot redux void", $"Rudeling (Void)" },
             { "Skuladot redux_shield", $"Rudeling w/ Shield" },
             { "Skuladot redux_shield_ghost", $"Rudeling w/ Shield (Ghost)" },
             { "Skuladot redux Big", $"Guard Captain" },
             { "Skuladot redux Big_ghost", $"Guard Captain (Ghost)" },
-
             { "Honourguard", $"Envoy" },
             { "beefboy", $"Beefboy" },
-
             { "Bat", $"Phrend" },
             { "Bat void", $"Phrend (Void)" },
-
             { "Spider Small", $"Spyrite" },
             { "Spider Big", $"Sappharach" },
-
             { "Spinnerbot Baby", $"Baby Slorm" },
             { "Spinnerbot Corrupted", $"Slorm" },
-
             { "Turret", $"Autobolt (Turret)" },
             { "Hedgehog Trap", $"Laser Trap" },
-
             { "sewertentacle", $"Tentacle" },
-
             { "Fairyprobe Archipelagos (Dmg)", $"Fairy" },
             { "Fairyprobe Archipelagos (Ghost)", $"Fairy (Ghost)" },
             { "Fairyprobe Archipelagos", $"Fairy (Ice)" },
-            
             { "crocodoo", $"Chompignom (Terry)" },
             { "crocodoo Voidtouched", $"Chompignom (Void)" },
-
             { "plover", $"Plover (Bluebirds)" },
-
             { "Crabbit", $"Crabbit" },
             { "Crabbit with Shell", $"Crabbit w/ Cube Shell" },
             { "Crabbo", $"Crabbo" },
-
             { "Crow", $"Husher" },
             { "Crow Voidtouched", $"Husher (Void)" },
-
             { "Frog", $"Frog" },
             { "Frog Small", $"Frog (Small)" },
-            { "Frog Small_Ghost", $"Frog (Small, Ghost.)" },
+            { "Frog Small_Ghost", $"Frog (Small Ghost)" },
             { "Frog Spear", $"Frog w/ Shield & Spear" },
             { "Frog Spear_Ghost", $"Frog w/ Shield & Spear (Ghost)" },
-
             { "administrator_servant", $"Administrator (Coffee Table)" },
-
             { "Wizard_Sword", $"Custodian" },
             { "Wizard_Candleabra", $"Custodian w/ Candelabra" },
             { "Wizard_Support", $"Custodian (Support)" },
-            { "Wizard_Support_Ghost", $"Custodian (Support, Ghost)" },
-
+            { "Wizard_Support_Ghost", $"Custodian (Support Ghost)" },
             { "Scavenger", $"Scavenger (Sniper)" },
             { "Scavenger_miner", $"Scavenger (Miner)" },
             { "Scavenger_support", $"Scavenger (Support)" },
             { "Scavenger_stunner", $"Scavenger (Ice Sniper)" },
-
             { "voidling redux", $"Voidling Spider" },
-
             { "administrator", $"Administrator" },
-            
             { "bomezome_easy", $"Fleemer" },
+            { "bomezome_easy_ghost", $"Fleemer (Ghost)" },
+            { "bomezome_easy_ghost (tweaked)", $"Fleemer (Big Ghost)" },
             { "bomezome_fencer", $"Fleemer (Fencer)" },
-            { "bomezome big", $"Big Fleemer" },
-            { "bomezome_easy_ghost", $"Fleemer (Ghost Var.)" },
-            { "bomezome_easy_ghost (tweaked)", $"Fleemer (Big, Ghost Var.)" },
-
+            { "bomezome big", $"Giant Fleemer" },
             { "Ghostfox_monster", $"Lost Echo" },
             { "Gunslinger", $"Gunslinger" },
-
             { "Fox enemy zombie", $"Fox Zombie" },
             { "Fox enemy", $"Fox Zombie (Strong)" },
-
             { "tunic knight void", $"Garden Knight (Ghost)" },
             { "Voidtouched", $"Voidtouched" },
-
+            { "Ghost Knight", $"Ghost Knight (Devworld)" },
+            { "Phage", $"Phage/Beta Slorm (Devworld)" },
             { "woodcutter", $"Woodcutter" },
             { "Centipede", $"Centipede" },
-            { "tech knight ghost", $"Garden Knight (Night Variant)" },
+            { "tech knight ghost", $"Garden Knight (Void)" },
             { "Shadowreaper", $"Shadowreaper" },
-            { "Ghost Knight", $"Ghost Knight (Devworld)" },
-            { "Phage", $"Beta Slorm (Devworld)" },
         };
         public static void CreateAreaSeeds() {
             System.Random Random = new System.Random(SaveFile.GetInt("seed"));

--- a/src/Patches/EnemyRandomizer.cs
+++ b/src/Patches/EnemyRandomizer.cs
@@ -380,6 +380,99 @@ namespace TunicRandomizer {
             { "Skuladot redux Big_ghost", $"\"Guard Captain...?\"" },
         };
 
+        public static Dictionary<string, string> EnemyToggleOptionNames = new Dictionary<string, string>() {
+            { "Blob", $"Blob" },
+            { "BlobBig", $"Big Blob" },
+            { "BlobBigger", $"Bigger Blob" },
+
+            { "Hedgehog", $"Hedgehog" },
+            { "HedgehogBig", $"Big Hedgehog" },
+
+            { "Skuladot redux", $"Rudeling" },
+            { "Skuladot redux void", $"Rudeling (Void)" },
+            { "Skuladot redux_ghost", $"Rudeling (Ghost)" },
+            { "Skuladot redux_shield", $"Rudeling w/ Shield" },
+            { "Skuladot redux_shield_ghost", $"Rudeling w/ Shield (Ghost)" },
+            { "Skuladot redux Big", $"Guard Captain" },
+            { "Skuladot redux Big_ghost", $"Guard Captain (Ghost)" },
+
+            { "Honourguard", $"Envoy" },
+            { "beefboy", $"Beefboy" },
+
+            { "Bat", $"Phrend" },
+            { "Bat void", $"Phrend (Void)" },
+
+            { "Spider Small", $"Spyrite" },
+            { "Spider Big", $"Sappharach" },
+
+            { "Spinnerbot Baby", $"Baby Slorm" },
+            { "Spinnerbot Corrupted", $"Slorm" },
+
+            { "Turret", $"Autobolt (Turret)" },
+            { "Hedgehog Trap", $"Laser Trap" },
+
+            { "sewertentacle", $"Tentacle" },
+
+            { "Fairyprobe Archipelagos (Dmg)", $"Fairy" },
+            { "Fairyprobe Archipelagos (Ghost)", $"Fairy (Ghost)" },
+            { "Fairyprobe Archipelagos", $"Fairy (Ice)" },
+            
+            { "crocodoo", $"Chompignom (Terry)" },
+            { "crocodoo Voidtouched", $"Chompignom (Void)" },
+
+            { "plover", $"Plover (Bluebirds)" },
+
+            { "Crabbit", $"Crabbit" },
+            { "Crabbit with Shell", $"Crabbit w/ Cube Shell" },
+            { "Crabbo", $"Crabbo" },
+
+            { "Crow", $"Husher" },
+            { "Crow Voidtouched", $"Husher (Void)" },
+
+            { "Frog", $"Frog" },
+            { "Frog Small", $"Frog (Small)" },
+            { "Frog Small_Ghost", $"Frog (Small, Ghost.)" },
+            { "Frog Spear", $"Frog w/ Shield & Spear" },
+            { "Frog Spear_Ghost", $"Frog w/ Shield & Spear (Ghost)" },
+
+            { "administrator_servant", $"Administrator (Coffee Table)" },
+
+            { "Wizard_Sword", $"Custodian" },
+            { "Wizard_Candleabra", $"Custodian w/ Candelabra" },
+            { "Wizard_Support", $"Custodian (Support)" },
+            { "Wizard_Support_Ghost", $"Custodian (Support, Ghost)" },
+
+            { "Scavenger", $"Scavenger (Sniper)" },
+            { "Scavenger_miner", $"Scavenger (Miner)" },
+            { "Scavenger_support", $"Scavenger (Support)" },
+            { "Scavenger_stunner", $"Scavenger (Ice Sniper)" },
+
+            { "voidling redux", $"Voidling Spider" },
+
+            { "administrator", $"Administrator" },
+            
+            { "bomezome_easy", $"Fleemer" },
+            { "bomezome_fencer", $"Fleemer (Fencer)" },
+            { "bomezome big", $"Big Fleemer" },
+            { "bomezome_easy_ghost", $"Fleemer (Ghost Var.)" },
+            { "bomezome_easy_ghost (tweaked)", $"Fleemer (Big, Ghost Var.)" },
+
+            { "Ghostfox_monster", $"Lost Echo" },
+            { "Gunslinger", $"Gunslinger" },
+
+            { "Fox enemy zombie", $"Fox Zombie" },
+            { "Fox enemy", $"Fox Zombie (Strong)" },
+
+            { "tunic knight void", $"Garden Knight (Ghost)" },
+            { "Voidtouched", $"Voidtouched" },
+
+            { "woodcutter", $"Woodcutter" },
+            { "Centipede", $"Centipede" },
+            { "tech knight ghost", $"Garden Knight (Night Variant)" },
+            { "Shadowreaper", $"Shadowreaper" },
+            { "Ghost Knight", $"Ghost Knight (Devworld)" },
+            { "Phage", $"Beta Slorm (Devworld)" },
+        };
         public static void CreateAreaSeeds() {
             System.Random Random = new System.Random(SaveFile.GetInt("seed"));
             foreach (String Scene in Locations.AllScenes) {
@@ -587,6 +680,17 @@ namespace TunicRandomizer {
                     EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "Skuladot redux Big" : "Skuladot redux Big_ghost");
                     EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "Bat" : "Bat void");
 
+                    if (TunicRandomizer.Settings.ExcludeEnemies) {
+                        foreach(KeyValuePair<string, string> enemyToggle in EnemyToggleOptionNames) {
+                            if (!TunicRandomizer.Settings.EnemyToggles[enemyToggle.Value] && EnemyKeys.Contains(enemyToggle.Key)) {
+                                EnemyKeys.Remove(enemyToggle.Key);
+                            }
+                        }
+                    }
+                    if (EnemyKeys.Count == 0) {
+                        GameObject.Destroy(Enemy.gameObject);
+                        continue;
+                    }
                     string NewEnemyName = "";
                     if (!TunicRandomizer.Settings.BalancedEnemies) {
                         NewEnemy = GameObject.Instantiate(Enemies[EnemyKeys[Random.Next(EnemyKeys.Count)]]);

--- a/src/Patches/EnemyRandomizer.cs
+++ b/src/Patches/EnemyRandomizer.cs
@@ -669,16 +669,6 @@ namespace TunicRandomizer {
                     if (DoNotPlaceTurretHere.Contains($"{CurrentScene} {Enemy.name}")) {
                         EnemyKeys.Remove("Turret");
                     }
-                    // Make alternate variants of certain enemies slightly less common
-                    EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "Frog Small" : "Frog Small_Ghost");
-                    EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "Frog Spear" : "Frog Spear_Ghost");
-                    EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "Fairyprobe Archipelagos" : "Fairyprobe Archipelagos (Ghost)");
-                    EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "bomezome_easy" : "bomezome_easy_ghost");
-                    EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "Wizard_Support" : "Wizard_Support_Ghost");
-                    EnemyKeys.Remove(Random.NextDouble() < 0.50 ? "Skuladot redux void" : "Skuladot redux_ghost");
-                    EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "Skuladot redux_shield" : "Skuladot redux_shield_ghost");
-                    EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "Skuladot redux Big" : "Skuladot redux Big_ghost");
-                    EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "Bat" : "Bat void");
 
                     if (TunicRandomizer.Settings.ExcludeEnemies) {
                         foreach(KeyValuePair<string, string> enemyToggle in EnemyToggleOptionNames) {
@@ -686,6 +676,17 @@ namespace TunicRandomizer {
                                 EnemyKeys.Remove(enemyToggle.Key);
                             }
                         }
+                    } else {
+                        // Make alternate variants of certain enemies slightly less common
+                        EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "Frog Small" : "Frog Small_Ghost");
+                        EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "Frog Spear" : "Frog Spear_Ghost");
+                        EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "Fairyprobe Archipelagos" : "Fairyprobe Archipelagos (Ghost)");
+                        EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "bomezome_easy" : "bomezome_easy_ghost");
+                        EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "Wizard_Support" : "Wizard_Support_Ghost");
+                        EnemyKeys.Remove(Random.NextDouble() < 0.50 ? "Skuladot redux void" : "Skuladot redux_ghost");
+                        EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "Skuladot redux_shield" : "Skuladot redux_shield_ghost");
+                        EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "Skuladot redux Big" : "Skuladot redux Big_ghost");
+                        EnemyKeys.Remove(Random.NextDouble() < 0.25 ? "Bat" : "Bat void");
                     }
                     if (EnemyKeys.Count == 0) {
                         GameObject.Destroy(Enemy.gameObject);
@@ -723,6 +724,10 @@ namespace TunicRandomizer {
                             NewEnemy = GameObject.Instantiate(Enemies[EnemyKeys[Random.Next(EnemyKeys.Count)]]);
                         } else {
                             EnemyTypes = EnemyTypes.Where(x => EnemyKeys.Contains(x)).ToList();
+                            if (EnemyTypes.Count == 0) {
+                                GameObject.Destroy(Enemy.gameObject);
+                                continue;
+                            }
                             NewEnemy = GameObject.Instantiate(Enemies[EnemyTypes[Random.Next(EnemyTypes.Count)]]);
                         }
                     }

--- a/src/Patches/OptionsGUIPatches.cs
+++ b/src/Patches/OptionsGUIPatches.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json;
 using static TunicRandomizer.SaveFlags;
 using static TunicRandomizer.RandomizerSettings;
 using UnityEngine.SceneManagement;
+using UnityEngine.UI;
 
 namespace TunicRandomizer {
     public class OptionsGUIPatches {
@@ -127,26 +128,36 @@ namespace TunicRandomizer {
             OptionsGUI.addToggle("Extra Enemies", "Off", "On", TunicRandomizer.Settings.ExtraEnemiesEnabled ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleExtraEnemies);
             OptionsGUI.addToggle("Balanced Enemies", "Off", "On", TunicRandomizer.Settings.BalancedEnemies ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleBalancedEnemies);
             OptionsGUI.addToggle("Seeded Enemies", "Off", "On", TunicRandomizer.Settings.SeededEnemies ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleSeededEnemies);
-            OptionsGUI.addToggle("Exclude Enemies", "Off", "On", TunicRandomizer.Settings.ExcludeEnemies ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleExcludeEnemies);
-            addPageButton("Excluded Enemy List", ExcludedEnemiesPage);
+            OptionsGUI.addToggle("Use Enemy Toggles", "Off", "On", TunicRandomizer.Settings.ExcludeEnemies ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleExcludeEnemies);
+            addPageButton("Enemy Toggle List", ExcludedEnemiesPage);
         }
 
         public static void ExcludedEnemiesPage() {
             OptionsGUI OptionsGUI = GameObject.FindObjectOfType<OptionsGUI>();
+            OptionsGUI.addButton("Toggle All Enemies ON", (Action)(() => {
+                GameObject.FindObjectsOfType<OptionsGUIMultiSelect>().ToList().ForEach((button) => { 
+                    button.SelectIndex(1);
+                    TunicRandomizer.Settings.EnemyToggles[button.leftAlignedText.text] = true;
+                });
+                SaveSettings();
+            })); 
+            OptionsGUI.addButton("Toggle All Enemies OFF", (Action)(() => {
+                GameObject.FindObjectsOfType<OptionsGUIMultiSelect>().ToList().ForEach((button) => {
+                    button.SelectIndex(0);
+                    TunicRandomizer.Settings.EnemyToggles[button.leftAlignedText.text] = false;
+                });
+                SaveSettings();
+            }));
             Dictionary<string, Action<int>> toggles = new Dictionary<string, Action<int>>();
-            foreach(string enemy in EnemyRandomizer.ProperEnemyNames.Keys) {
+            foreach(string enemy in EnemyRandomizer.EnemyToggleOptionNames.Values) {
                 toggles.Add(enemy, (int index) => {
-                    TunicRandomizer.Settings.ExcludedEnemyList[enemy] = !TunicRandomizer.Settings.ExcludedEnemyList[enemy];
+                    TunicRandomizer.Settings.EnemyToggles[enemy] = !TunicRandomizer.Settings.EnemyToggles[enemy];
                     SaveSettings();
                 });
             }
-            foreach (string enemy in EnemyRandomizer.ProperEnemyNames.Keys) {
-                OptionsGUI.addToggle(enemy, "Off", "On", TunicRandomizer.Settings.ExcludedEnemyList[enemy] ? 0 : 1, (OptionsGUIMultiSelect.MultiSelectAction)toggles[enemy]);
+            foreach (string enemy in EnemyRandomizer.EnemyToggleOptionNames.Values) {
+                OptionsGUI.addToggle(enemy, "Off", "On", TunicRandomizer.Settings.EnemyToggles[enemy] ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)toggles[enemy]);
             }
-        }
-
-        public static void ExcludeEnemy(int index) {
-            SaveSettings();
         }
 
         public static void CustomFoxSettingsPage() {

--- a/src/Patches/OptionsGUIPatches.cs
+++ b/src/Patches/OptionsGUIPatches.cs
@@ -129,7 +129,7 @@ namespace TunicRandomizer {
             OptionsGUI.addToggle("Balanced Enemies", "Off", "On", TunicRandomizer.Settings.BalancedEnemies ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleBalancedEnemies);
             OptionsGUI.addToggle("Seeded Enemies", "Off", "On", TunicRandomizer.Settings.SeededEnemies ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleSeededEnemies);
             OptionsGUI.addToggle("Use Enemy Toggles", "Off", "On", TunicRandomizer.Settings.ExcludeEnemies ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleExcludeEnemies);
-            addPageButton("Enemy Toggle List", ExcludedEnemiesPage);
+            addPageButton("Configure Enemy Toggles", ExcludedEnemiesPage);
         }
 
         public static void ExcludedEnemiesPage() {

--- a/src/Patches/OptionsGUIPatches.cs
+++ b/src/Patches/OptionsGUIPatches.cs
@@ -127,6 +127,26 @@ namespace TunicRandomizer {
             OptionsGUI.addToggle("Extra Enemies", "Off", "On", TunicRandomizer.Settings.ExtraEnemiesEnabled ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleExtraEnemies);
             OptionsGUI.addToggle("Balanced Enemies", "Off", "On", TunicRandomizer.Settings.BalancedEnemies ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleBalancedEnemies);
             OptionsGUI.addToggle("Seeded Enemies", "Off", "On", TunicRandomizer.Settings.SeededEnemies ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleSeededEnemies);
+            OptionsGUI.addToggle("Exclude Enemies", "Off", "On", TunicRandomizer.Settings.ExcludeEnemies ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleExcludeEnemies);
+            addPageButton("Excluded Enemy List", ExcludedEnemiesPage);
+        }
+
+        public static void ExcludedEnemiesPage() {
+            OptionsGUI OptionsGUI = GameObject.FindObjectOfType<OptionsGUI>();
+            Dictionary<string, Action<int>> toggles = new Dictionary<string, Action<int>>();
+            foreach(string enemy in EnemyRandomizer.ProperEnemyNames.Keys) {
+                toggles.Add(enemy, (int index) => {
+                    TunicRandomizer.Settings.ExcludedEnemyList[enemy] = !TunicRandomizer.Settings.ExcludedEnemyList[enemy];
+                    SaveSettings();
+                });
+            }
+            foreach (string enemy in EnemyRandomizer.ProperEnemyNames.Keys) {
+                OptionsGUI.addToggle(enemy, "Off", "On", TunicRandomizer.Settings.ExcludedEnemyList[enemy] ? 0 : 1, (OptionsGUIMultiSelect.MultiSelectAction)toggles[enemy]);
+            }
+        }
+
+        public static void ExcludeEnemy(int index) {
+            SaveSettings();
         }
 
         public static void CustomFoxSettingsPage() {
@@ -438,6 +458,12 @@ namespace TunicRandomizer {
             SaveSettings();
         }
 
+        public static void ToggleExcludeEnemies(int index) {
+            TunicRandomizer.Settings.ExcludeEnemies = !TunicRandomizer.Settings.ExcludeEnemies;
+            SaveSettings();
+        }
+
+        // Other
         public static void ToggleWeirdMode(int index) {
             TunicRandomizer.Settings.CameraFlip = !TunicRandomizer.Settings.CameraFlip;
             CameraController.Flip = TunicRandomizer.Settings.CameraFlip;


### PR DESCRIPTION
- Added toggles for every enemy, allowing you to choose what enemies are able to spawn when the enemy randomizer is on
- If every enemy is toggled off, no enemies will spawn
- Added the enemy toggle settings to the copy/paste settings string