### PR TITLE
Music shuffle feature

### DIFF
--- a/TunicRandomizer.csproj
+++ b/TunicRandomizer.csproj
@@ -191,6 +191,7 @@
     <Compile Include="src\Patches\InteractionPatches.cs" />
     <Compile Include="src\Patches\ItemPresentationPatches.cs" />
     <Compile Include="src\Patches\ItemRandomizer.cs" />
+    <Compile Include="src\Patches\MusicShuffler.cs" />
     <Compile Include="src\Patches\QuickSettings.cs" />
     <Compile Include="src\Patches\FairyTargets.cs" />
     <Compile Include="src\Patches\ModelSwaps.cs" />

--- a/src/Data/RandomizerSettings.cs
+++ b/src/Data/RandomizerSettings.cs
@@ -175,6 +175,7 @@ namespace TunicRandomizer {
         private const int ARACHNOPHOBIA_MODE = 1024;
         private const int HOLY_CROSS_VIEWER = 2048;
         private const int MUSIC_SHUFFLE = 4096;
+        private const int SEEDED_MUSIC = 8192;
         public bool HeirAssistModeEnabled {
             get;
             set;
@@ -237,6 +238,16 @@ namespace TunicRandomizer {
         }
 
         public bool MusicShuffle {
+            get;
+            set;
+        }
+
+        public bool SeededMusic {
+            get;
+            set;
+        }
+
+        public Dictionary<string, bool> MusicToggles {
             get;
             set;
         }
@@ -413,6 +424,11 @@ namespace TunicRandomizer {
             ArachnophobiaMode = false;
             HolyCrossVisualizer = false;
             MusicShuffle = false;
+            SeededMusic = false;
+            MusicToggles = new Dictionary<string, bool>();
+            foreach(string track in MusicShuffler.Tracks.Keys) {
+                MusicToggles.Add(track, true);
+            }
 
             // Enemy Randomizer
             EnemyRandomizerEnabled = false;
@@ -508,6 +524,7 @@ namespace TunicRandomizer {
                 ArachnophobiaMode = eval(general, ARACHNOPHOBIA_MODE);
                 HolyCrossVisualizer = eval(general, HOLY_CROSS_VIEWER);
                 MusicShuffle = eval(general, MUSIC_SHUFFLE);
+                SeededMusic = eval(general, SEEDED_MUSIC);
 
                 int hints = int.Parse(decodedSplit[6]);
                 HeroPathHintsEnabled = eval(hints, PATH_OF_HERO);
@@ -575,7 +592,7 @@ namespace TunicRandomizer {
         public bool[] generalSettings() {
             return new bool[] { HeirAssistModeEnabled, ClearEarlyBushes, EnableAllCheckpoints, CheaperShopItemsEnabled, 
                 BonusStatUpgradesEnabled, DisableChestInterruption, SkipItemAnimations, FasterUpgrades, CameraFlip, MoreSkulls, 
-                ArachnophobiaMode, HolyCrossVisualizer, MusicShuffle, };
+                ArachnophobiaMode, HolyCrossVisualizer, MusicShuffle, SeededMusic };
         }
 
         public bool[] hintSettings() {

--- a/src/Data/RandomizerSettings.cs
+++ b/src/Data/RandomizerSettings.cs
@@ -174,6 +174,7 @@ namespace TunicRandomizer {
         private const int MORE_SKULLS = 512;
         private const int ARACHNOPHOBIA_MODE = 1024;
         private const int HOLY_CROSS_VIEWER = 2048;
+        private const int MUSIC_SHUFFLE = 4096;
         public bool HeirAssistModeEnabled {
             get;
             set;
@@ -231,6 +232,11 @@ namespace TunicRandomizer {
         }
 
         public bool HolyCrossVisualizer {
+            get;
+            set;
+        }
+
+        public bool MusicShuffle {
             get;
             set;
         }
@@ -406,6 +412,7 @@ namespace TunicRandomizer {
             MoreSkulls = false;
             ArachnophobiaMode = false;
             HolyCrossVisualizer = false;
+            MusicShuffle = false;
 
             // Enemy Randomizer
             EnemyRandomizerEnabled = false;
@@ -500,6 +507,7 @@ namespace TunicRandomizer {
                 MoreSkulls = eval(general, MORE_SKULLS);
                 ArachnophobiaMode = eval(general, ARACHNOPHOBIA_MODE);
                 HolyCrossVisualizer = eval(general, HOLY_CROSS_VIEWER);
+                MusicShuffle = eval(general, MUSIC_SHUFFLE);
 
                 int hints = int.Parse(decodedSplit[6]);
                 HeroPathHintsEnabled = eval(hints, PATH_OF_HERO);
@@ -566,7 +574,8 @@ namespace TunicRandomizer {
 
         public bool[] generalSettings() {
             return new bool[] { HeirAssistModeEnabled, ClearEarlyBushes, EnableAllCheckpoints, CheaperShopItemsEnabled, 
-                BonusStatUpgradesEnabled, DisableChestInterruption, SkipItemAnimations, FasterUpgrades, CameraFlip, MoreSkulls, ArachnophobiaMode, HolyCrossVisualizer };
+                BonusStatUpgradesEnabled, DisableChestInterruption, SkipItemAnimations, FasterUpgrades, CameraFlip, MoreSkulls, 
+                ArachnophobiaMode, HolyCrossVisualizer, MusicShuffle, };
         }
 
         public bool[] hintSettings() {

--- a/src/Patches/EnemyRandomizer.cs
+++ b/src/Patches/EnemyRandomizer.cs
@@ -994,6 +994,9 @@ namespace TunicRandomizer {
                         NewEnemy.GetComponent<Foxgod>().rainPreview_pool.pool = FoxgodPools[4].ToArray();
                         NewEnemy.GetComponent<Foxgod>().voidhole_pool = FoxgodBossfightRoot.transform.GetChild(0).GetChild(5).GetComponent<PooledFX>();
                         NewEnemy.GetComponent<Foxgod>().voidhole_pool.pool = FoxgodPools[5].ToArray();
+                        if (CurrentScene != "Cathedral Arena") {
+                            NewEnemy.GetComponent<Foxgod>().IsAggroed = true;
+                        }
                     }
 
                     NewEnemy.name += $" {i}";

--- a/src/Patches/InteractionPatches.cs
+++ b/src/Patches/InteractionPatches.cs
@@ -215,7 +215,7 @@ namespace TunicRandomizer {
         }
 
         public static bool ConduitNode_CheckConnectedToPower_PrefixPatch(ConduitNode __instance, ref bool __result) {
-            if (TunicRandomizer.Settings.EnableAllCheckpoints && __instance.GetComponent<Campfire>() != null && __instance.GetComponent<UpgradeAltar>() != null) {
+            if (TunicRandomizer.Settings.EnableAllCheckpoints && __instance != null && __instance.GetComponent<Campfire>() != null && __instance.GetComponent<UpgradeAltar>() != null) {
                 __result = true;
                 return false;
             }

--- a/src/Patches/MusicShuffler.cs
+++ b/src/Patches/MusicShuffler.cs
@@ -1,0 +1,279 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+using FMODUnity;
+
+namespace TunicRandomizer {
+    public class MusicShuffler : MonoBehaviour {
+
+        public string trackToShuffle = "";
+        public Queue<(string, int)> paramsToSet;
+        public static MusicShuffler instance;
+        public float TimeSinceMusicStart = 0f;
+
+        public void Start() {
+            instance = this;
+            paramsToSet = new Queue<(string, int)>();
+        }
+
+        public void Update() {
+            if (Time.time > TimeSinceMusicStart + 1f) {
+                if (paramsToSet.Count > 0) {
+                    (string, int) param = paramsToSet.Dequeue();
+                    MusicManager.SetParam(param.Item1, param.Item2);
+                }
+            }    
+        }
+
+        public static void PlayMusicOnLoad_Start_PostfixPatch(PlayMusicOnLoad __instance) {
+            if (TunicRandomizer.Settings.MusicShuffle) {
+                List<string> songOptions = Tracks.Keys.Where(t => t != MusicShuffler.instance.trackToShuffle).ToList();
+/*                songOptions = new List<string>() {
+                    "Guard Captain", "Gauntlet Fight"
+                };*/
+                string trackName = songOptions[new System.Random().Next(songOptions.Count)];
+                MusicShuffler.instance.trackToShuffle = trackName;
+                MusicShuffler.instance.paramsToSet.Clear();
+                __instance.track = Tracks[trackName];
+                if (MusicManager.playingEventRef.Guid.ToString() == Tracks[trackName].Guid.ToString()) {
+                    MusicManager.Stop();
+                    MusicManager.PlayNewTrackIfDifferent(Tracks[trackName]);
+                }
+                if (TrackParams.ContainsKey(trackName)) {
+                    foreach ((string, int) param in TrackParams[trackName]) {
+                        MusicShuffler.instance.paramsToSet.Enqueue(param);
+                    }
+                }
+                MusicShuffler.instance.TimeSinceMusicStart = Time.time;
+                TunicLogger.LogInfo("playing track " + __instance.track.Guid.ToString() + " " + trackName);
+            }
+        }
+
+        public static void MusicManager_PlayCuedTrack_PostfixPatch(ref string paramString, ref int value) {
+            TunicLogger.LogInfo("Music Manager setparam " + paramString + " to " + value);
+        }
+
+        public static Dictionary<string, EventReference> Tracks = new Dictionary<string, EventReference>() {
+            { "TitleScreen", CreateEventReference("4fe73372-6fde-463e-9610-128523c3fb2c") },
+            //{ "Sword Cave", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
+            //{ "Ruined Shop", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
+            { "Town Basement", CreateEventReference("b952baa7-7650-42b1-8ce7-a0bbbc7f2c48") },
+            //{ "Ruins Passage", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
+            //{ "Mountaintop", CreateEventReference("0bfe5f44-c371-4e7f-81db-e2c16c353b53") },
+            //{ "Forest Boss Room", CreateEventReference("3656fc56-77ff-4482-8a30-7ce0ca203f80") },
+            //{ "Sword Access", CreateEventReference("89e5d635-fa19-4740-9264-d11e065f24c4") },
+            { "Fortress Main", CreateEventReference("57f6adc6-e38b-4fb0-8939-b9d0db907ee7") },
+            //{ "Fortress Basement", CreateEventReference("11dec94a-4683-4130-95c9-cdedd7796b8d") },
+            { "Fortress Courtyard", CreateEventReference("bc9a21da-a3bd-4c95-bdd0-cda8cb2c5a75") }, // Needs work
+            { "Dusty", CreateEventReference("194c4ddb-576d-426a-bdc5-f643421be010") }, // Needs work
+            // { "Fortress Arena", CreateEventReference("3656fc56-77ff-4482-8a30-7ce0ca203f80") },
+            // { "Ziggurat_Arena", CreateEventReference("b1c8230c-fdc7-4709-9655-e65906ccb778") },
+            { "Library", CreateEventReference("32cfeb38-3fd4-435c-91fa-0d1b24e156dd") },
+            //{ "Library Hall", CreateEventReference("32cfeb38-3fd4-435c-91fa-0d1b24e156dd") },
+            //{ "Library Rotunda", CreateEventReference("32cfeb38-3fd4-435c-91fa-0d1b24e156dd") },
+            //{ "Quarry", CreateEventReference("971a6110-1297-42a5-a1b8-e6c4a277a266") },
+            //{ "Monastery", CreateEventReference("971a6110-1297-42a5-a1b8-e6c4a277a266") },
+            { "Darkwoods Tunnel", CreateEventReference("ac3dcf2b-d7bb-47a0-ab3a-52ff47d177eb") },
+            { "Temple", CreateEventReference("1e9ff9c7-c594-4323-948d-dd1673c83af3") },
+            { "Overworld Redux East", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
+            { "Overworld Redux West", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
+            { "Overworld Redux Subarea", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
+            { "Old House", CreateEventReference("16b40cc0-d208-45be-a4bf-0f88d450331f") },
+            { "Sewer", CreateEventReference("c604f3e9-9e43-4e4d-90f8-ac083bfbf3c5") },
+            //{ "Library Arena", CreateEventReference("3656fc56-77ff-4482-8a30-7ce0ca203f80") },
+            //{ "Crypt", CreateEventReference("c604f3e9-9e43-4e4d-90f8-ac083bfbf3c5") },
+            //{ "Town_FiligreeRoom", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
+            { "Archipelagos Redux", CreateEventReference("a66bad80-45fa-41a4-a3a3-2a324b053df9") },
+            { "Atoll Redux", CreateEventReference("a1564c7c-c6c7-4bee-874b-6ed9c13ce9dd") },
+            //{ "Frog Stairs", CreateEventReference("a1564c7c-c6c7-4bee-874b-6ed9c13ce9dd") },
+            { "Library Exterior", CreateEventReference("cd23eb08-387f-422e-8ea2-e7adef2e58fb") },
+            //{ "Void", CreateEventReference("3656fc56-77ff-4482-8a30-7ce0ca203f80") },
+            //{ "Forest Belltower", CreateEventReference("3656fc56-77ff-4482-8a30-7ce0ca203f80") },
+            { "Playable Intro", CreateEventReference("077841ff-76f6-445a-9a4e-2f79a43c4b0f") },
+            { "Resurrection", CreateEventReference("b733e6d5-eef5-49b4-9366-ff8d808c7cc2") },
+            { "Transit", CreateEventReference("d3cdded7-01d4-470f-815f-44da75c006b5") },
+            //{ "archipelagos_house", CreateEventReference("a66bad80-45fa-41a4-a3a3-2a324b053df9") },
+            { "ziggurat2020_1", CreateEventReference("bedf573b-c194-47b7-8ccd-e0c2f1f13e67") },
+            { "ziggurat2020_2", CreateEventReference("80ced6fe-8a9a-41d2-ae76-d7329a281229") },
+            { "Lower Ziggurat", CreateEventReference("889c2828-480a-4c8e-85b8-edc132d7f62a") },
+            { "Administrators", CreateEventReference("889c2828-480a-4c8e-85b8-edc132d7f62a") },
+            { "Boss Scavenger Approach", CreateEventReference("889c2828-480a-4c8e-85b8-edc132d7f62a") },
+            { "Boss Scavenger", CreateEventReference("889c2828-480a-4c8e-85b8-edc132d7f62a") },
+            //{ "ziggurat2020_0", CreateEventReference("3656fc56-77ff-4482-8a30-7ce0ca203f80") },
+            //{ "ziggurat2020_FTRoom", CreateEventReference("3656fc56-77ff-4482-8a30-7ce0ca203f80") },
+            //{ "Fortress East", CreateEventReference("89e5d635-fa19-4740-9264-d11e065f24c4") },
+            //{ "Fortress Reliquary", CreateEventReference("89e5d635-fa19-4740-9264-d11e065f24c4") },
+            { "Waterfall", CreateEventReference("b7f9dae0-180c-4f6c-8c51-9ae776f9f1a4") },
+            { "Overworld Cave", CreateEventReference("31c4fbbd-b9ee-4b09-a90a-890960bd3218") },
+            //{ "Sewer_Boss", CreateEventReference("c604f3e9-9e43-4e4d-90f8-ac083bfbf3c5") },
+            { "frog cave main", CreateEventReference("1e666263-aca1-49ab-a5b2-8730ef0b2e9f") },
+            { "East Forest Redux", CreateEventReference("89e5d635-fa19-4740-9264-d11e065f24c4") },
+            //{ "East Forest Redux Interior", CreateEventReference("89e5d635-fa19-4740-9264-d11e065f24c4") },
+            //{ "East Forest Redux Laddercave", CreateEventReference("89e5d635-fa19-4740-9264-d11e065f24c4") },
+            { "Shop", CreateEventReference("efd407da-eca0-4d4e-9d3a-088708245e9d") },
+            { "Furnace", CreateEventReference("521eb8bd-41fb-4d6b-a768-057484cae6ad") },
+            //{ "Windmill", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
+            { "Swamp Redux 2", CreateEventReference("b5c30739-61f7-4b9e-a32b-afb59a74fe18") },
+            { "Quarry Redux", CreateEventReference("971a6110-1297-42a5-a1b8-e6c4a277a266") },
+            { "Cathedral Arena", CreateEventReference("47cf75f3-eff4-4644-9db1-f68569778b27") },
+            { "RelicVoid", CreateEventReference("e850a9d9-8bcf-4f9d-aa2c-e222cc25d9f7") },
+            { "Spirit Arena", CreateEventReference("02895d64-5723-4514-badb-dc4a42d4416b") },
+            { "Crypt Redux", CreateEventReference("2ec4f10f-0411-47b2-b7d2-8cf7b90915a4") },
+            //{ "ShopSpecial", CreateEventReference("efd407da-eca0-4d4e-9d3a-088708245e9d") },
+            { "CubeRoom", CreateEventReference("5fc4f540-24c1-4fa6-b5fc-eafe34e5fc7a") },
+            //{ "PatrolCave", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
+            //{ "Maze Room", CreateEventReference("3656fc56-77ff-4482-8a30-7ce0ca203f80") },
+            { "Cathedral Redux", CreateEventReference("736aa4f4-e742-47c5-ad43-1da341de0f3c") },
+            { "Mountain", CreateEventReference("0bfe5f44-c371-4e7f-81db-e2c16c353b53") },
+            { "Golden Path", CreateEventReference("0bfe5f44-c371-4e7f-81db-e2c16c353b53") },
+            { "Changing Room", CreateEventReference("cca553ae-48bb-401b-bd67-970273469fb8") },
+            //{ "DungeonAudioTest", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
+            { "Purgatory", CreateEventReference("71025492-2ca8-4f59-8db2-fe6b13d1379f") },
+            //{ "g_elements", CreateEventReference("077841ff-76f6-445a-9a4e-2f79a43c4b0f") },
+            { "Guard Captain", CreateEventReference("ec13435f-fba0-42e7-8278-d990f2b68f2b") },
+            { "Garden Knight", CreateEventReference("17d077e6-339e-429f-aed1-b1265e1765b6") },
+            { "Siege Engine", CreateEventReference("6b50e51c-ef86-4073-a688-c72bc2fdcd10") },
+            { "Librarian", CreateEventReference("f81317c6-0b17-4532-b4df-8cee40efb48f") },
+            { "Gauntlet Fight", CreateEventReference("266d48e6-bc9e-4a3f-ae46-a845ea3cd925") },
+            { "Credits Good", CreateEventReference("5587b38b-32ff-4fe3-b46a-00214874cb71") },
+            { "Credits Bad", CreateEventReference("106735eb-a4d2-49bf-a40f-5157a6a86155") },
+            { "Game Over", CreateEventReference("8a1af5ad-d7ee-44c8-9ec1-4f975a44a23c") },
+            { "The End", CreateEventReference("259824e8-5ebb-40bc-aa21-9600a7867c2e") },
+            { "The Heir Phase 1", CreateEventReference("02895d64-5723-4514-badb-dc4a42d4416b") },
+            { "The Heir Phase 2", CreateEventReference("02895d64-5723-4514-badb-dc4a42d4416b") },
+        };
+
+    public static Dictionary<string, List<(string, int)>> TrackParams = new Dictionary<string, List<(string, int)>>() {
+            { 
+                "Lower Ziggurat", new List<(string, int)>() {
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "overworld_layer_2", 1 ),
+                    ( "overworld_layer_1", 0 ),
+                }
+            },
+            {
+                "Administrators", new List<(string, int)>() {
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 0 ),
+                    ( "zig_3_location_index", 1 ),
+                }
+            },
+            {
+                "Boss Scavenger Approach", new List<(string, int)>() {
+                    ( "zig_3_miniboss_dead", 0),
+                    ( "fuse_expanse_boss_approach", 0),
+                    ( "zig_3_location_index", 2 ),
+                    ( "zig_3_location_index", 3 ),
+                    ( "boss_layerB_volume", 1 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "zig_3_location_index", 2 ),
+                    ( "zig_3_location_index", 3 ),
+                }
+            },
+            {
+                "Boss Scavenger", new List<(string, int)>() {
+                    ( "boss_aggroed", 0 ),
+                    ( "zig_3_location_index", 2 ),
+                    ( "zig_3_location_index", 3 ),
+                    ( "boss_layerB_volume", 1 ),
+                    ( "boss_aggroed", 1 ),
+                }
+            },
+            {
+                "Overworld Redux East", new List<(string, int)>() {
+                    ( "overworld_layer_1", 1 ),
+                    ( "overworld_layer_2", 0 ),
+                    ( "overworld_layer_3", 0 ),
+                }
+            },
+            {
+                "Overworld Redux West", new List<(string, int)>() {
+                    ( "overworld_layer_1", 0 ),
+                    ( "overworld_layer_2", 1 ),
+                    ( "overworld_layer_3", 0 ),
+                }
+            },
+            {
+                "Overworld Redux Subarea", new List<(string, int)>() {
+                    ( "overworld_layer_1", 0 ),
+                    ( "overworld_layer_2", 0 ),
+                    ( "overworld_layer_3", 1 ),
+                }
+            },
+            {
+                "Old House", new List<(string, int)>() {
+                    ( "overworldInteriors_oldHouse", 1 ),
+                    ( "overworld_layer_1", 0 ),
+                    ( "overworld_layer_2", 0 ),
+                    ( "overworld_layer_3", 1 ),
+                }
+            },
+            {
+                "The Heir Phase 1", new List<(string, int)>() {
+                    ( "foxgod_phase", 0 ),
+                    ( "foxgod_phase", 1 ),
+                }
+            },
+            {
+                "The Heir Phase 2", new List<(string, int)>() {
+                    ( "foxgod_phase", 1 ),
+                    ( "foxgod_phase", 1 ),
+                    ( "foxgod_phase", 1 ),
+                    ( "foxgod_phase", 1 ),
+                    ( "foxgod_phase", 1 ),
+                    ( "foxgod_phase", 1 ),
+                    ( "foxgod_phase", 2 ),
+                    ( "foxgod_phase", 2 ),
+                    ( "foxgod_phase", 2 ),
+                    ( "foxgod_phase", 2 ),
+                }
+            },
+            {
+                "Golden Path", new List<(string, int)>() {
+                    ( "mountain_door_state", 1 ),
+                    ( "mountain_door_state", 2 ),
+                    ( "mountain_door_state", 2 ),
+                    ( "mountain_door_state", 2 ),
+                    ( "mountain_door_state", 2 ),
+                    ( "mountain_door_state", 2 ),
+                    ( "mountain_door_state", 2 ),
+                    ( "mountain_door_state", 2 ),
+                    ( "mountain_door_state", 2 ),
+                }
+            },
+            {
+                "ziggurat2020_1", new List<(string, int)>() {
+                    ( "zig1_elevator_finish", 1 ),
+                }
+            }
+        };
+
+        public static EventReference CreateEventReference(string Guid) {
+            EventReference e = new EventReference();
+            e.Guid = FMOD.GUID.Parse(Guid);
+            return e;
+        }
+    }
+}

--- a/src/Patches/MusicShuffler.cs
+++ b/src/Patches/MusicShuffler.cs
@@ -26,7 +26,6 @@ namespace TunicRandomizer {
             if (Time.time > TimeSinceMusicStart + 1.5f) {
                 if (paramsToSet.Count > 0) {
                     (string, int) param = paramsToSet.Dequeue();
-                    TunicLogger.LogInfo("dequeued " + param.Item1 + " " + param.Item2);
                     MusicManager.SetParam(param.Item1, param.Item2);
                 }
             }
@@ -34,7 +33,6 @@ namespace TunicRandomizer {
             if (Time.realtimeSinceStartup > TimeSinceMusicStart + 2f) {
                 if (paramsToSetRealtime.Count > 0) {
                     (string, int) param = paramsToSetRealtime.Dequeue();
-                    TunicLogger.LogInfo("dequeued " + param.Item1 + " " + param.Item2);
                     MusicManager.SetParam(param.Item1, param.Item2);
                 }
             }
@@ -42,23 +40,38 @@ namespace TunicRandomizer {
 
         public static void PlayMusicOnLoad_Start_PostfixPatch(PlayMusicOnLoad __instance) {
             if (TunicRandomizer.Settings.MusicShuffle) {
-                List<string> songOptions = Tracks.Keys.Where(t => t != MusicShuffler.instance.trackToShuffle).ToList();
-/*                songOptions = new List<string>() {
-                    "Guard Captain", "Gauntlet Fight"
-                };*/
-                string trackName = songOptions[new System.Random().Next(songOptions.Count)];
+                foreach(AudioParamTrigger trigger in GameObject.FindObjectsOfType<AudioParamTrigger>()) {
+                    trigger.enabled = false;
+                }
+                List<string> songOptions = Tracks.Keys.Where(track => TunicRandomizer.Settings.MusicToggles[track]).ToList();
+                if (songOptions.Count == 0) {
+                    return;
+                }
+                System.Random random;
+                if (TunicRandomizer.Settings.SeededMusic && __instance.gameObject.scene.name != "TitleScreen") {
+                    random = new System.Random(SaveFile.GetInt($"randomizer enemy seed {__instance.gameObject.scene.name}"));
+                } else {
+                    random = new System.Random();
+                }
+
+                string trackName = songOptions[random.Next(songOptions.Count)];
                 MusicShuffler.instance.trackToShuffle = trackName;
                 MusicShuffler.instance.paramsToSet.Clear();
                 __instance.track = Tracks[trackName];
                 if (MusicManager.playingEventRef.Guid.ToString() == Tracks[trackName].Guid.ToString()) {
-                    MusicManager.Stop();
+                    MusicManager.StopImmediate();
                     MusicManager.PlayNewTrackIfDifferent(Tracks[trackName]);
                 }
                 if (TrackParams.ContainsKey(trackName)) {
                     foreach ((string, int) param in TrackParams[trackName]) {
-                        TunicLogger.LogInfo("queueing " + param.Item1 + " " + param.Item1);
                         MusicShuffler.instance.paramsToSet.Enqueue(param);
                     }
+                }
+                if (trackName == "Cube Cave" && GameObject.FindObjectOfType<RotatingCubeClue>() == null) {
+                    GameObject cube = new GameObject("cube for music track");
+                    cube.AddComponent<RotatingCubeClue>();
+                    cube.GetComponent<RotatingCubeClue>().sequence = "rrrruuuurrruuurruuru";
+                    cube.transform.parent = __instance.transform;
                 }
                 MusicShuffler.instance.TimeSinceMusicStart = Time.time;
                 TunicLogger.LogInfo("playing track " + __instance.track.Guid.ToString() + " " + trackName);
@@ -71,46 +84,37 @@ namespace TunicRandomizer {
 
         public static Dictionary<string, EventReference> Tracks = new Dictionary<string, EventReference>() {
             { "Title Screen", CreateEventReference("4fe73372-6fde-463e-9610-128523c3fb2c") },
-            
             { "Overworld East", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
             { "Overworld West", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
             { "Overworld Subarea", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
-            
             { "Intro Cutscene Area", CreateEventReference("077841ff-76f6-445a-9a4e-2f79a43c4b0f") },
-            { "Resurrection", CreateEventReference("b733e6d5-eef5-49b4-9366-ff8d808c7cc2") },
-            { "Old House", CreateEventReference("16b40cc0-d208-45be-a4bf-0f88d450331f") },
-            { "Caustic Lights", CreateEventReference("31c4fbbd-b9ee-4b09-a90a-890960bd3218") },
-            { "Hourglass Cave", CreateEventReference("b952baa7-7650-42b1-8ce7-a0bbbc7f2c48") },
-            { "Cube Cave", CreateEventReference("5fc4f540-24c1-4fa6-b5fc-eafe34e5fc7a") }, // Needs work
-            { "Changing Room", CreateEventReference("cca553ae-48bb-401b-bd67-970273469fb8") },
-            { "Secret Gathering Place", CreateEventReference("b7f9dae0-180c-4f6c-8c51-9ae776f9f1a4") },
-            { "Shop", CreateEventReference("efd407da-eca0-4d4e-9d3a-088708245e9d") },
-            
             { "East Forest", CreateEventReference("89e5d635-fa19-4740-9264-d11e065f24c4") },
             { "Guard Captain", CreateEventReference("ec13435f-fba0-42e7-8278-d990f2b68f2b") },
-
-            { "Sealed Temple", CreateEventReference("1e9ff9c7-c594-4323-948d-dd1673c83af3") },
-            { "Far Shore", CreateEventReference("d3cdded7-01d4-470f-815f-44da75c006b5") },
-
+            { "Resurrection", CreateEventReference("b733e6d5-eef5-49b4-9366-ff8d808c7cc2") },
+            { "Shop", CreateEventReference("efd407da-eca0-4d4e-9d3a-088708245e9d") },
+            { "Old House", CreateEventReference("16b40cc0-d208-45be-a4bf-0f88d450331f") },
+            { "Changing Room", CreateEventReference("cca553ae-48bb-401b-bd67-970273469fb8") },
+            { "Hourglass Cave", CreateEventReference("b952baa7-7650-42b1-8ce7-a0bbbc7f2c48") },
+            { "Caustic Lights", CreateEventReference("31c4fbbd-b9ee-4b09-a90a-890960bd3218") },
+            { "Cube Cave", CreateEventReference("5fc4f540-24c1-4fa6-b5fc-eafe34e5fc7a") },
+            { "Secret Gathering Place", CreateEventReference("b7f9dae0-180c-4f6c-8c51-9ae776f9f1a4") },
             { "Beneath the Well", CreateEventReference("c604f3e9-9e43-4e4d-90f8-ac083bfbf3c5") },
             { "West Furnace", CreateEventReference("521eb8bd-41fb-4d6b-a768-057484cae6ad") },
             { "Dark Tomb", CreateEventReference("2ec4f10f-0411-47b2-b7d2-8cf7b90915a4") },
-
             { "West Garden", CreateEventReference("a66bad80-45fa-41a4-a3a3-2a324b053df9") },
             { "Garden Knight", CreateEventReference("17d077e6-339e-429f-aed1-b1265e1765b6") },
-
+            { "Sealed Temple", CreateEventReference("1e9ff9c7-c594-4323-948d-dd1673c83af3") },
+            { "Far Shore", CreateEventReference("d3cdded7-01d4-470f-815f-44da75c006b5") },
             { "Fortress Courtyard", CreateEventReference("bc9a21da-a3bd-4c95-bdd0-cda8cb2c5a75") },
             { "Beneath the Vault", CreateEventReference("11dec94a-4683-4130-95c9-cdedd7796b8d") },
             { "Eastern Vault Fortress", CreateEventReference("57f6adc6-e38b-4fb0-8939-b9d0db907ee7") },
             { "Fortress Leaf Piles", CreateEventReference("194c4ddb-576d-426a-bdc5-f643421be010") },
             { "Siege Engine", CreateEventReference("6b50e51c-ef86-4073-a688-c72bc2fdcd10") },
-
             { "Ruined Atoll", CreateEventReference("a1564c7c-c6c7-4bee-874b-6ed9c13ce9dd") },
             { "Frog's Domain", CreateEventReference("1e666263-aca1-49ab-a5b2-8730ef0b2e9f") },
             { "Library Exterior", CreateEventReference("cd23eb08-387f-422e-8ea2-e7adef2e58fb") },
             { "Library Interior", CreateEventReference("32cfeb38-3fd4-435c-91fa-0d1b24e156dd") },
             { "Librarian", CreateEventReference("f81317c6-0b17-4532-b4df-8cee40efb48f") },
-            
             { "Quarry Entrance", CreateEventReference("ac3dcf2b-d7bb-47a0-ab3a-52ff47d177eb") },
             { "Quarry", CreateEventReference("971a6110-1297-42a5-a1b8-e6c4a277a266") },
             { "Upper Ziggurat", CreateEventReference("bedf573b-c194-47b7-8ccd-e0c2f1f13e67") },
@@ -119,31 +123,35 @@ namespace TunicRandomizer {
             { "Administrators", CreateEventReference("889c2828-480a-4c8e-85b8-edc132d7f62a") },
             { "Boss Scavenger Approach", CreateEventReference("889c2828-480a-4c8e-85b8-edc132d7f62a") },
             { "Boss Scavenger", CreateEventReference("889c2828-480a-4c8e-85b8-edc132d7f62a") },
-            
             { "Swamp", CreateEventReference("b5c30739-61f7-4b9e-a32b-afb59a74fe18") },
             { "Cathedral", CreateEventReference("736aa4f4-e742-47c5-ad43-1da341de0f3c") },
-            { "Cathedral Gauntlet", CreateEventReference("47cf75f3-eff4-4644-9db1-f68569778b27") },
+            { "Gauntlet Ambience", CreateEventReference("47cf75f3-eff4-4644-9db1-f68569778b27") },
             { "Gauntlet Fight", CreateEventReference("266d48e6-bc9e-4a3f-ae46-a845ea3cd925") },
-            
             { "Mountain", CreateEventReference("0bfe5f44-c371-4e7f-81db-e2c16c353b53") },
             { "Mountain (Golden Path)", CreateEventReference("0bfe5f44-c371-4e7f-81db-e2c16c353b53") },
-            
             { "Hero's Grave", CreateEventReference("e850a9d9-8bcf-4f9d-aa2c-e222cc25d9f7") },
-
+            { "Purgatory (Secret Save)", CreateEventReference("71025492-2ca8-4f59-8db2-fe6b13d1379f") },
+            { "Secret Legend", CreateEventReference("16b40cc0-d208-45be-a4bf-0f88d450331f") },
             { "Spirit Arena", CreateEventReference("02895d64-5723-4514-badb-dc4a42d4416b") },
             { "The Heir (1st Encounter)", CreateEventReference("02895d64-5723-4514-badb-dc4a42d4416b") },
             { "The Heir", CreateEventReference("02895d64-5723-4514-badb-dc4a42d4416b") },
-
             { "Credits A", CreateEventReference("5587b38b-32ff-4fe3-b46a-00214874cb71") },
             { "Credits B", CreateEventReference("106735eb-a4d2-49bf-a40f-5157a6a86155") },
             { "Game Over", CreateEventReference("8a1af5ad-d7ee-44c8-9ec1-4f975a44a23c") },
             { "The End", CreateEventReference("259824e8-5ebb-40bc-aa21-9600a7867c2e") },
-            { "Purgatory", CreateEventReference("71025492-2ca8-4f59-8db2-fe6b13d1379f") },
         };
 
     public static Dictionary<string, List<(string, int)>> TrackParams = new Dictionary<string, List<(string, int)>>() {
             { 
                 "Lower Ziggurat", new List<(string, int)>() {
+                    ( "zig_3_boss_dead", 0 ),
+                    ( "zig_3_fuse_closed", 0 ),
+                    ( "fuse_expanse_already_seen", 0 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "zig_3_boss_dead", 0 ),
+                    ( "zig_3_fuse_closed", 0 ),
+                    ( "fuse_expanse_already_seen", 0 ),
+                    ( "boss_aggroed", 0 ),
                     ( "zig_3_location_index", 0 ),
                     ( "zig_3_location_index", 0 ),
                     ( "zig_3_location_index", 0 ),
@@ -164,6 +172,14 @@ namespace TunicRandomizer {
             },
             {
                 "Administrators", new List<(string, int)>() {
+                    ( "zig_3_boss_dead", 0 ),
+                    ( "zig_3_fuse_closed", 0 ),
+                    ( "fuse_expanse_already_seen", 0 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "zig_3_boss_dead", 0 ),
+                    ( "zig_3_fuse_closed", 0 ),
+                    ( "fuse_expanse_already_seen", 0 ),
+                    ( "boss_aggroed", 0 ),
                     ( "zig_3_location_index", 0 ),
                     ( "zig_3_location_index", 0 ),
                     ( "zig_3_location_index", 0 ),
@@ -176,22 +192,114 @@ namespace TunicRandomizer {
             },
             {
                 "Boss Scavenger Approach", new List<(string, int)>() {
+                    ( "zig_3_boss_dead", 0 ),
+                    ( "zig_3_fuse_closed", 0 ),
+                    ( "fuse_expanse_already_seen", 0 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "zig_3_boss_dead", 0 ),
+                    ( "zig_3_fuse_closed", 0 ),
+                    ( "fuse_expanse_already_seen", 0 ),
+                    ( "boss_aggroed", 0 ),
                     ( "zig_3_miniboss_dead", 0),
-                    ( "fuse_expanse_boss_approach", 0),
+                    ( "fuse_expanse_already_seen", 1 ),
+                    ( "fuse_expanse_boss_approach", 1),
                     ( "zig_3_location_index", 2 ),
                     ( "zig_3_location_index", 3 ),
                     ( "boss_layerB_volume", 1 ),
+                    ( "zig_boss_layerB_volume", 1 ),
                     ( "boss_aggroed", 0 ),
+                    ( "zig_3_boss_dead", 0 ),
+                    ( "zig_3_fuse_closed", 0 ),
+                    ( "fuse_expanse_already_seen", 0 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "zig_3_boss_dead", 0 ),
+                    ( "zig_3_fuse_closed", 0 ),
+                    ( "fuse_expanse_already_seen", 0 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "zig_3_miniboss_dead", 0),
+                    ( "fuse_expanse_already_seen", 1 ),
+                    ( "fuse_expanse_boss_approach", 1),
                     ( "zig_3_location_index", 2 ),
                     ( "zig_3_location_index", 3 ),
+                    ( "boss_layerB_volume", 1 ),
+                    ( "zig_boss_layerB_volume", 1 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "zig_3_boss_dead", 0 ),
+                    ( "zig_3_fuse_closed", 0 ),
+                    ( "fuse_expanse_already_seen", 0 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "zig_3_boss_dead", 0 ),
+                    ( "zig_3_fuse_closed", 0 ),
+                    ( "fuse_expanse_already_seen", 0 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "zig_3_miniboss_dead", 0),
+                    ( "fuse_expanse_already_seen", 1 ),
+                    ( "fuse_expanse_boss_approach", 1),
+                    ( "zig_3_location_index", 2 ),
+                    ( "zig_3_location_index", 3 ),
+                    ( "boss_layerB_volume", 1 ),
+                    ( "zig_boss_layerB_volume", 1 ),
+                    ( "boss_aggroed", 0 ),
                 }
             },
             {
                 "Boss Scavenger", new List<(string, int)>() {
+                    ( "zig_3_boss_dead", 0 ),
+                    ( "zig_3_fuse_closed", 0 ),
+                    ( "fuse_expanse_already_seen", 0 ),
                     ( "boss_aggroed", 0 ),
+                    ( "zig_3_boss_dead", 0 ),
+                    ( "zig_3_fuse_closed", 0 ),
+                    ( "fuse_expanse_already_seen", 0 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "fuse_expanse_already_seen", 1 ),
+                    ( "fuse_expanse_boss_approach", 1),
                     ( "zig_3_location_index", 2 ),
                     ( "zig_3_location_index", 3 ),
                     ( "boss_layerB_volume", 1 ),
+                    ( "zig_boss_layerB_volume", 1 ),
+                    ( "boss_aggroed", 1 ),
+                    ( "boss_aggroed", 1 ),
+                    ( "boss_aggroed", 1 ),
+                    ( "boss_aggroed", 1 ),
+                    ( "zig_3_boss_dead", 0 ),
+                    ( "zig_3_fuse_closed", 0 ),
+                    ( "fuse_expanse_already_seen", 0 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "zig_3_boss_dead", 0 ),
+                    ( "zig_3_fuse_closed", 0 ),
+                    ( "fuse_expanse_already_seen", 0 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "fuse_expanse_already_seen", 1 ),
+                    ( "fuse_expanse_boss_approach", 1),
+                    ( "zig_3_location_index", 2 ),
+                    ( "zig_3_location_index", 3 ),
+                    ( "boss_layerB_volume", 1 ),
+                    ( "zig_boss_layerB_volume", 1 ),
+                    ( "boss_aggroed", 1 ),
+                    ( "boss_aggroed", 1 ),
+                    ( "boss_aggroed", 1 ),
+                    ( "boss_aggroed", 1 ),
+                    ( "zig_3_boss_dead", 0 ),
+                    ( "zig_3_fuse_closed", 0 ),
+                    ( "fuse_expanse_already_seen", 0 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "zig_3_boss_dead", 0 ),
+                    ( "zig_3_fuse_closed", 0 ),
+                    ( "fuse_expanse_already_seen", 0 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "boss_aggroed", 0 ),
+                    ( "fuse_expanse_already_seen", 1 ),
+                    ( "fuse_expanse_boss_approach", 1),
+                    ( "zig_3_location_index", 2 ),
+                    ( "zig_3_location_index", 3 ),
+                    ( "boss_layerB_volume", 1 ),
+                    ( "zig_boss_layerB_volume", 1 ),
+                    ( "boss_aggroed", 1 ),
+                    ( "boss_aggroed", 1 ),
+                    ( "boss_aggroed", 1 ),
                     ( "boss_aggroed", 1 ),
                 }
             },
@@ -225,6 +333,16 @@ namespace TunicRandomizer {
                 }
             },
             {
+                "Secret Legend", new List<(string, int)>() {
+                    ( "overworldInteriors_location", 1 ),
+                    ( "overworldInteriors_trophyRoom", 1 ),
+                    ( "overworldInteriors_oldHouse", 0 ),
+                    ( "overworld_layer_1", 0 ),
+                    ( "overworld_layer_2", 0 ),
+                    ( "overworld_layer_3", 1 ),
+                }
+            },
+            {
                 "The Heir", new List<(string, int)>() {
                     ( "foxgod_phase", 0 ),
                     ( "foxgod_phase", 1 ),
@@ -245,7 +363,7 @@ namespace TunicRandomizer {
                 }
             },
             {
-                "Golden Path", new List<(string, int)>() {
+                "Mountain (Golden Path)", new List<(string, int)>() {
                     ( "mountain_door_state", 1 ),
                     ( "mountain_door_state", 2 ),
                     ( "mountain_door_state", 2 ),

--- a/src/Patches/MusicShuffler.cs
+++ b/src/Patches/MusicShuffler.cs
@@ -12,21 +12,32 @@ namespace TunicRandomizer {
 
         public string trackToShuffle = "";
         public Queue<(string, int)> paramsToSet;
+        public Queue<(string, int)> paramsToSetRealtime;
         public static MusicShuffler instance;
         public float TimeSinceMusicStart = 0f;
 
         public void Start() {
             instance = this;
             paramsToSet = new Queue<(string, int)>();
+            paramsToSetRealtime = new Queue<(string, int)>();
         }
 
         public void Update() {
-            if (Time.time > TimeSinceMusicStart + 1f) {
+            if (Time.time > TimeSinceMusicStart + 1.5f) {
                 if (paramsToSet.Count > 0) {
                     (string, int) param = paramsToSet.Dequeue();
+                    TunicLogger.LogInfo("dequeued " + param.Item1 + " " + param.Item2);
                     MusicManager.SetParam(param.Item1, param.Item2);
                 }
-            }    
+            }
+
+            if (Time.realtimeSinceStartup > TimeSinceMusicStart + 2f) {
+                if (paramsToSetRealtime.Count > 0) {
+                    (string, int) param = paramsToSetRealtime.Dequeue();
+                    TunicLogger.LogInfo("dequeued " + param.Item1 + " " + param.Item2);
+                    MusicManager.SetParam(param.Item1, param.Item2);
+                }
+            }
         }
 
         public static void PlayMusicOnLoad_Start_PostfixPatch(PlayMusicOnLoad __instance) {
@@ -45,6 +56,7 @@ namespace TunicRandomizer {
                 }
                 if (TrackParams.ContainsKey(trackName)) {
                     foreach ((string, int) param in TrackParams[trackName]) {
+                        TunicLogger.LogInfo("queueing " + param.Item1 + " " + param.Item1);
                         MusicShuffler.instance.paramsToSet.Enqueue(param);
                     }
                 }
@@ -58,93 +70,75 @@ namespace TunicRandomizer {
         }
 
         public static Dictionary<string, EventReference> Tracks = new Dictionary<string, EventReference>() {
-            { "TitleScreen", CreateEventReference("4fe73372-6fde-463e-9610-128523c3fb2c") },
-            //{ "Sword Cave", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
-            //{ "Ruined Shop", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
-            { "Town Basement", CreateEventReference("b952baa7-7650-42b1-8ce7-a0bbbc7f2c48") },
-            //{ "Ruins Passage", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
-            //{ "Mountaintop", CreateEventReference("0bfe5f44-c371-4e7f-81db-e2c16c353b53") },
-            //{ "Forest Boss Room", CreateEventReference("3656fc56-77ff-4482-8a30-7ce0ca203f80") },
-            //{ "Sword Access", CreateEventReference("89e5d635-fa19-4740-9264-d11e065f24c4") },
-            { "Fortress Main", CreateEventReference("57f6adc6-e38b-4fb0-8939-b9d0db907ee7") },
-            //{ "Fortress Basement", CreateEventReference("11dec94a-4683-4130-95c9-cdedd7796b8d") },
-            { "Fortress Courtyard", CreateEventReference("bc9a21da-a3bd-4c95-bdd0-cda8cb2c5a75") }, // Needs work
-            { "Dusty", CreateEventReference("194c4ddb-576d-426a-bdc5-f643421be010") }, // Needs work
-            // { "Fortress Arena", CreateEventReference("3656fc56-77ff-4482-8a30-7ce0ca203f80") },
-            // { "Ziggurat_Arena", CreateEventReference("b1c8230c-fdc7-4709-9655-e65906ccb778") },
-            { "Library", CreateEventReference("32cfeb38-3fd4-435c-91fa-0d1b24e156dd") },
-            //{ "Library Hall", CreateEventReference("32cfeb38-3fd4-435c-91fa-0d1b24e156dd") },
-            //{ "Library Rotunda", CreateEventReference("32cfeb38-3fd4-435c-91fa-0d1b24e156dd") },
-            //{ "Quarry", CreateEventReference("971a6110-1297-42a5-a1b8-e6c4a277a266") },
-            //{ "Monastery", CreateEventReference("971a6110-1297-42a5-a1b8-e6c4a277a266") },
-            { "Darkwoods Tunnel", CreateEventReference("ac3dcf2b-d7bb-47a0-ab3a-52ff47d177eb") },
-            { "Temple", CreateEventReference("1e9ff9c7-c594-4323-948d-dd1673c83af3") },
-            { "Overworld Redux East", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
-            { "Overworld Redux West", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
-            { "Overworld Redux Subarea", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
-            { "Old House", CreateEventReference("16b40cc0-d208-45be-a4bf-0f88d450331f") },
-            { "Sewer", CreateEventReference("c604f3e9-9e43-4e4d-90f8-ac083bfbf3c5") },
-            //{ "Library Arena", CreateEventReference("3656fc56-77ff-4482-8a30-7ce0ca203f80") },
-            //{ "Crypt", CreateEventReference("c604f3e9-9e43-4e4d-90f8-ac083bfbf3c5") },
-            //{ "Town_FiligreeRoom", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
-            { "Archipelagos Redux", CreateEventReference("a66bad80-45fa-41a4-a3a3-2a324b053df9") },
-            { "Atoll Redux", CreateEventReference("a1564c7c-c6c7-4bee-874b-6ed9c13ce9dd") },
-            //{ "Frog Stairs", CreateEventReference("a1564c7c-c6c7-4bee-874b-6ed9c13ce9dd") },
-            { "Library Exterior", CreateEventReference("cd23eb08-387f-422e-8ea2-e7adef2e58fb") },
-            //{ "Void", CreateEventReference("3656fc56-77ff-4482-8a30-7ce0ca203f80") },
-            //{ "Forest Belltower", CreateEventReference("3656fc56-77ff-4482-8a30-7ce0ca203f80") },
-            { "Playable Intro", CreateEventReference("077841ff-76f6-445a-9a4e-2f79a43c4b0f") },
+            { "Title Screen", CreateEventReference("4fe73372-6fde-463e-9610-128523c3fb2c") },
+            
+            { "Overworld East", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
+            { "Overworld West", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
+            { "Overworld Subarea", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
+            
+            { "Intro Cutscene Area", CreateEventReference("077841ff-76f6-445a-9a4e-2f79a43c4b0f") },
             { "Resurrection", CreateEventReference("b733e6d5-eef5-49b4-9366-ff8d808c7cc2") },
-            { "Transit", CreateEventReference("d3cdded7-01d4-470f-815f-44da75c006b5") },
-            //{ "archipelagos_house", CreateEventReference("a66bad80-45fa-41a4-a3a3-2a324b053df9") },
-            { "ziggurat2020_1", CreateEventReference("bedf573b-c194-47b7-8ccd-e0c2f1f13e67") },
-            { "ziggurat2020_2", CreateEventReference("80ced6fe-8a9a-41d2-ae76-d7329a281229") },
+            { "Old House", CreateEventReference("16b40cc0-d208-45be-a4bf-0f88d450331f") },
+            { "Caustic Lights", CreateEventReference("31c4fbbd-b9ee-4b09-a90a-890960bd3218") },
+            { "Hourglass Cave", CreateEventReference("b952baa7-7650-42b1-8ce7-a0bbbc7f2c48") },
+            { "Cube Cave", CreateEventReference("5fc4f540-24c1-4fa6-b5fc-eafe34e5fc7a") }, // Needs work
+            { "Changing Room", CreateEventReference("cca553ae-48bb-401b-bd67-970273469fb8") },
+            { "Secret Gathering Place", CreateEventReference("b7f9dae0-180c-4f6c-8c51-9ae776f9f1a4") },
+            { "Shop", CreateEventReference("efd407da-eca0-4d4e-9d3a-088708245e9d") },
+            
+            { "East Forest", CreateEventReference("89e5d635-fa19-4740-9264-d11e065f24c4") },
+            { "Guard Captain", CreateEventReference("ec13435f-fba0-42e7-8278-d990f2b68f2b") },
+
+            { "Sealed Temple", CreateEventReference("1e9ff9c7-c594-4323-948d-dd1673c83af3") },
+            { "Far Shore", CreateEventReference("d3cdded7-01d4-470f-815f-44da75c006b5") },
+
+            { "Beneath the Well", CreateEventReference("c604f3e9-9e43-4e4d-90f8-ac083bfbf3c5") },
+            { "West Furnace", CreateEventReference("521eb8bd-41fb-4d6b-a768-057484cae6ad") },
+            { "Dark Tomb", CreateEventReference("2ec4f10f-0411-47b2-b7d2-8cf7b90915a4") },
+
+            { "West Garden", CreateEventReference("a66bad80-45fa-41a4-a3a3-2a324b053df9") },
+            { "Garden Knight", CreateEventReference("17d077e6-339e-429f-aed1-b1265e1765b6") },
+
+            { "Fortress Courtyard", CreateEventReference("bc9a21da-a3bd-4c95-bdd0-cda8cb2c5a75") },
+            { "Beneath the Vault", CreateEventReference("11dec94a-4683-4130-95c9-cdedd7796b8d") },
+            { "Eastern Vault Fortress", CreateEventReference("57f6adc6-e38b-4fb0-8939-b9d0db907ee7") },
+            { "Fortress Leaf Piles", CreateEventReference("194c4ddb-576d-426a-bdc5-f643421be010") },
+            { "Siege Engine", CreateEventReference("6b50e51c-ef86-4073-a688-c72bc2fdcd10") },
+
+            { "Ruined Atoll", CreateEventReference("a1564c7c-c6c7-4bee-874b-6ed9c13ce9dd") },
+            { "Frog's Domain", CreateEventReference("1e666263-aca1-49ab-a5b2-8730ef0b2e9f") },
+            { "Library Exterior", CreateEventReference("cd23eb08-387f-422e-8ea2-e7adef2e58fb") },
+            { "Library Interior", CreateEventReference("32cfeb38-3fd4-435c-91fa-0d1b24e156dd") },
+            { "Librarian", CreateEventReference("f81317c6-0b17-4532-b4df-8cee40efb48f") },
+            
+            { "Quarry Entrance", CreateEventReference("ac3dcf2b-d7bb-47a0-ab3a-52ff47d177eb") },
+            { "Quarry", CreateEventReference("971a6110-1297-42a5-a1b8-e6c4a277a266") },
+            { "Upper Ziggurat", CreateEventReference("bedf573b-c194-47b7-8ccd-e0c2f1f13e67") },
+            { "Ziggurat Tower", CreateEventReference("80ced6fe-8a9a-41d2-ae76-d7329a281229") },
             { "Lower Ziggurat", CreateEventReference("889c2828-480a-4c8e-85b8-edc132d7f62a") },
             { "Administrators", CreateEventReference("889c2828-480a-4c8e-85b8-edc132d7f62a") },
             { "Boss Scavenger Approach", CreateEventReference("889c2828-480a-4c8e-85b8-edc132d7f62a") },
             { "Boss Scavenger", CreateEventReference("889c2828-480a-4c8e-85b8-edc132d7f62a") },
-            //{ "ziggurat2020_0", CreateEventReference("3656fc56-77ff-4482-8a30-7ce0ca203f80") },
-            //{ "ziggurat2020_FTRoom", CreateEventReference("3656fc56-77ff-4482-8a30-7ce0ca203f80") },
-            //{ "Fortress East", CreateEventReference("89e5d635-fa19-4740-9264-d11e065f24c4") },
-            //{ "Fortress Reliquary", CreateEventReference("89e5d635-fa19-4740-9264-d11e065f24c4") },
-            { "Waterfall", CreateEventReference("b7f9dae0-180c-4f6c-8c51-9ae776f9f1a4") },
-            { "Overworld Cave", CreateEventReference("31c4fbbd-b9ee-4b09-a90a-890960bd3218") },
-            //{ "Sewer_Boss", CreateEventReference("c604f3e9-9e43-4e4d-90f8-ac083bfbf3c5") },
-            { "frog cave main", CreateEventReference("1e666263-aca1-49ab-a5b2-8730ef0b2e9f") },
-            { "East Forest Redux", CreateEventReference("89e5d635-fa19-4740-9264-d11e065f24c4") },
-            //{ "East Forest Redux Interior", CreateEventReference("89e5d635-fa19-4740-9264-d11e065f24c4") },
-            //{ "East Forest Redux Laddercave", CreateEventReference("89e5d635-fa19-4740-9264-d11e065f24c4") },
-            { "Shop", CreateEventReference("efd407da-eca0-4d4e-9d3a-088708245e9d") },
-            { "Furnace", CreateEventReference("521eb8bd-41fb-4d6b-a768-057484cae6ad") },
-            //{ "Windmill", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
-            { "Swamp Redux 2", CreateEventReference("b5c30739-61f7-4b9e-a32b-afb59a74fe18") },
-            { "Quarry Redux", CreateEventReference("971a6110-1297-42a5-a1b8-e6c4a277a266") },
-            { "Cathedral Arena", CreateEventReference("47cf75f3-eff4-4644-9db1-f68569778b27") },
-            { "RelicVoid", CreateEventReference("e850a9d9-8bcf-4f9d-aa2c-e222cc25d9f7") },
-            { "Spirit Arena", CreateEventReference("02895d64-5723-4514-badb-dc4a42d4416b") },
-            { "Crypt Redux", CreateEventReference("2ec4f10f-0411-47b2-b7d2-8cf7b90915a4") },
-            //{ "ShopSpecial", CreateEventReference("efd407da-eca0-4d4e-9d3a-088708245e9d") },
-            { "CubeRoom", CreateEventReference("5fc4f540-24c1-4fa6-b5fc-eafe34e5fc7a") },
-            //{ "PatrolCave", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
-            //{ "Maze Room", CreateEventReference("3656fc56-77ff-4482-8a30-7ce0ca203f80") },
-            { "Cathedral Redux", CreateEventReference("736aa4f4-e742-47c5-ad43-1da341de0f3c") },
-            { "Mountain", CreateEventReference("0bfe5f44-c371-4e7f-81db-e2c16c353b53") },
-            { "Golden Path", CreateEventReference("0bfe5f44-c371-4e7f-81db-e2c16c353b53") },
-            { "Changing Room", CreateEventReference("cca553ae-48bb-401b-bd67-970273469fb8") },
-            //{ "DungeonAudioTest", CreateEventReference("017d5f1e-bd27-468b-abd6-7fdef923f0aa") },
-            { "Purgatory", CreateEventReference("71025492-2ca8-4f59-8db2-fe6b13d1379f") },
-            //{ "g_elements", CreateEventReference("077841ff-76f6-445a-9a4e-2f79a43c4b0f") },
-            { "Guard Captain", CreateEventReference("ec13435f-fba0-42e7-8278-d990f2b68f2b") },
-            { "Garden Knight", CreateEventReference("17d077e6-339e-429f-aed1-b1265e1765b6") },
-            { "Siege Engine", CreateEventReference("6b50e51c-ef86-4073-a688-c72bc2fdcd10") },
-            { "Librarian", CreateEventReference("f81317c6-0b17-4532-b4df-8cee40efb48f") },
+            
+            { "Swamp", CreateEventReference("b5c30739-61f7-4b9e-a32b-afb59a74fe18") },
+            { "Cathedral", CreateEventReference("736aa4f4-e742-47c5-ad43-1da341de0f3c") },
+            { "Cathedral Gauntlet", CreateEventReference("47cf75f3-eff4-4644-9db1-f68569778b27") },
             { "Gauntlet Fight", CreateEventReference("266d48e6-bc9e-4a3f-ae46-a845ea3cd925") },
-            { "Credits Good", CreateEventReference("5587b38b-32ff-4fe3-b46a-00214874cb71") },
-            { "Credits Bad", CreateEventReference("106735eb-a4d2-49bf-a40f-5157a6a86155") },
+            
+            { "Mountain", CreateEventReference("0bfe5f44-c371-4e7f-81db-e2c16c353b53") },
+            { "Mountain (Golden Path)", CreateEventReference("0bfe5f44-c371-4e7f-81db-e2c16c353b53") },
+            
+            { "Hero's Grave", CreateEventReference("e850a9d9-8bcf-4f9d-aa2c-e222cc25d9f7") },
+
+            { "Spirit Arena", CreateEventReference("02895d64-5723-4514-badb-dc4a42d4416b") },
+            { "The Heir (1st Encounter)", CreateEventReference("02895d64-5723-4514-badb-dc4a42d4416b") },
+            { "The Heir", CreateEventReference("02895d64-5723-4514-badb-dc4a42d4416b") },
+
+            { "Credits A", CreateEventReference("5587b38b-32ff-4fe3-b46a-00214874cb71") },
+            { "Credits B", CreateEventReference("106735eb-a4d2-49bf-a40f-5157a6a86155") },
             { "Game Over", CreateEventReference("8a1af5ad-d7ee-44c8-9ec1-4f975a44a23c") },
             { "The End", CreateEventReference("259824e8-5ebb-40bc-aa21-9600a7867c2e") },
-            { "The Heir Phase 1", CreateEventReference("02895d64-5723-4514-badb-dc4a42d4416b") },
-            { "The Heir Phase 2", CreateEventReference("02895d64-5723-4514-badb-dc4a42d4416b") },
+            { "Purgatory", CreateEventReference("71025492-2ca8-4f59-8db2-fe6b13d1379f") },
         };
 
     public static Dictionary<string, List<(string, int)>> TrackParams = new Dictionary<string, List<(string, int)>>() {
@@ -202,21 +196,21 @@ namespace TunicRandomizer {
                 }
             },
             {
-                "Overworld Redux East", new List<(string, int)>() {
+                "Overworld East", new List<(string, int)>() {
                     ( "overworld_layer_1", 1 ),
                     ( "overworld_layer_2", 0 ),
                     ( "overworld_layer_3", 0 ),
                 }
             },
             {
-                "Overworld Redux West", new List<(string, int)>() {
+                "Overworld West", new List<(string, int)>() {
                     ( "overworld_layer_1", 0 ),
                     ( "overworld_layer_2", 1 ),
                     ( "overworld_layer_3", 0 ),
                 }
             },
             {
-                "Overworld Redux Subarea", new List<(string, int)>() {
+                "Overworld Subarea", new List<(string, int)>() {
                     ( "overworld_layer_1", 0 ),
                     ( "overworld_layer_2", 0 ),
                     ( "overworld_layer_3", 1 ),
@@ -231,13 +225,13 @@ namespace TunicRandomizer {
                 }
             },
             {
-                "The Heir Phase 1", new List<(string, int)>() {
+                "The Heir", new List<(string, int)>() {
                     ( "foxgod_phase", 0 ),
                     ( "foxgod_phase", 1 ),
                 }
             },
             {
-                "The Heir Phase 2", new List<(string, int)>() {
+                "The Heir (1st Encounter)", new List<(string, int)>() {
                     ( "foxgod_phase", 1 ),
                     ( "foxgod_phase", 1 ),
                     ( "foxgod_phase", 1 ),
@@ -264,8 +258,21 @@ namespace TunicRandomizer {
                 }
             },
             {
-                "ziggurat2020_1", new List<(string, int)>() {
+                "Upper Ziggurat", new List<(string, int)>() {
                     ( "zig1_elevator_finish", 1 ),
+                }
+            },
+            {
+                "Beneath the Vault", new List<(string, int)>() {
+                    ( "fortressBasement_musicBegin", 1 ),
+                }
+            },
+            {
+                "Fortress Courtyard", new List<(string, int)>() {
+                    ( "layer_insideWalls", 0 ),
+                    ( "layer_outsideWalls", 1 ),
+                    ( "layer_prefuse", 1 ),
+                    ( "inside_the_walls", 1 ),
                 }
             }
         };

--- a/src/Patches/OptionsGUIPatches.cs
+++ b/src/Patches/OptionsGUIPatches.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json;
 using static TunicRandomizer.SaveFlags;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
+using FMODUnity;
 
 namespace TunicRandomizer {
     public class OptionsGUIPatches {
@@ -204,8 +205,29 @@ namespace TunicRandomizer {
             OptionsGUI.addToggle("More Skulls", "Off", "On", TunicRandomizer.Settings.MoreSkulls ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleMoreSkulls);
             OptionsGUI.addToggle("Arachnophobia Mode", "Off", "On", TunicRandomizer.Settings.ArachnophobiaMode ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleArachnophobiaMode);
             OptionsGUI.addToggle("Holy Cross DDR", "Off", "On", TunicRandomizer.Settings.HolyCrossVisualizer ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleHolyCrossViewer);
+            OptionsGUI.addToggle("Music Shuffle", "Off", "On", TunicRandomizer.Settings.MusicShuffle ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)((int index) => { TunicRandomizer.Settings.MusicShuffle = !TunicRandomizer.Settings.MusicShuffle; SaveSettings(); }));
+            //addPageButton("Jukebox", JukeboxPage);
             if (SecretMayor.shouldBeActive || SecretMayor.isCorrectDate()) {
                 OptionsGUI.addToggle("Mr Mayor", "Off", "On", SecretMayor.shouldBeActive ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)SecretMayor.ToggleMayorSecret);
+            }
+        }
+
+        public static void JukeboxPage() {
+            OptionsGUI OptionsGUI = GameObject.FindObjectOfType<OptionsGUI>();
+            OptionsGUI.setHeading("Music");
+
+            foreach (KeyValuePair<string, EventReference> pair in MusicShuffler.Tracks) {
+                OptionsGUI.addButton(Locations.SimplifiedSceneNames.ContainsKey(pair.Key) ? Locations.SimplifiedSceneNames[pair.Key] : pair.Key, 
+                    (Action)(() => {
+                        MusicManager.Stop();
+                        MusicManager.PlayNewTrackIfDifferent(pair.Value);
+                        if (MusicShuffler.TrackParams.ContainsKey(pair.Key)) {
+                            foreach ((string, int) param in MusicShuffler.TrackParams[pair.Key]) {
+                                MusicShuffler.instance.paramsToSet.Enqueue(param);
+                            }
+                            MusicShuffler.instance.TimeSinceMusicStart = Time.time;
+                        }
+                    }));
             }
         }
 

--- a/src/Patches/OptionsGUIPatches.cs
+++ b/src/Patches/OptionsGUIPatches.cs
@@ -206,7 +206,7 @@ namespace TunicRandomizer {
             OptionsGUI.addToggle("Arachnophobia Mode", "Off", "On", TunicRandomizer.Settings.ArachnophobiaMode ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleArachnophobiaMode);
             OptionsGUI.addToggle("Holy Cross DDR", "Off", "On", TunicRandomizer.Settings.HolyCrossVisualizer ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleHolyCrossViewer);
             OptionsGUI.addToggle("Music Shuffle", "Off", "On", TunicRandomizer.Settings.MusicShuffle ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)((int index) => { TunicRandomizer.Settings.MusicShuffle = !TunicRandomizer.Settings.MusicShuffle; SaveSettings(); }));
-            //addPageButton("Jukebox", JukeboxPage);
+            addPageButton("Jukebox", JukeboxPage);
             if (SecretMayor.shouldBeActive || SecretMayor.isCorrectDate()) {
                 OptionsGUI.addToggle("Mr Mayor", "Off", "On", SecretMayor.shouldBeActive ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)SecretMayor.ToggleMayorSecret);
             }
@@ -217,15 +217,16 @@ namespace TunicRandomizer {
             OptionsGUI.setHeading("Music");
 
             foreach (KeyValuePair<string, EventReference> pair in MusicShuffler.Tracks) {
-                OptionsGUI.addButton(Locations.SimplifiedSceneNames.ContainsKey(pair.Key) ? Locations.SimplifiedSceneNames[pair.Key] : pair.Key, 
+                OptionsGUI.addButton(pair.Key, 
                     (Action)(() => {
                         MusicManager.Stop();
                         MusicManager.PlayNewTrackIfDifferent(pair.Value);
+                        MusicShuffler.instance.TimeSinceMusicStart = Time.realtimeSinceStartup;
                         if (MusicShuffler.TrackParams.ContainsKey(pair.Key)) {
                             foreach ((string, int) param in MusicShuffler.TrackParams[pair.Key]) {
-                                MusicShuffler.instance.paramsToSet.Enqueue(param);
+                                TunicLogger.LogInfo("queueing " + param.Item1 + " " + param.Item2);
+                                MusicShuffler.instance.paramsToSetRealtime.Enqueue(param);
                             }
-                            MusicShuffler.instance.TimeSinceMusicStart = Time.time;
                         }
                     }));
             }

--- a/src/Patches/OptionsGUIPatches.cs
+++ b/src/Patches/OptionsGUIPatches.cs
@@ -29,8 +29,9 @@ namespace TunicRandomizer {
             addPageButton("Archipelago Settings", ArchipelagoSettingsPage);
             addPageButton("Hint Settings", HintsSettingsPage);
             addPageButton("Enemy Randomizer Settings", EnemyRandomizerSettings);
-            addPageButton("Fox Customization", CustomFoxSettingsPage);
+            addPageButton("Fox Customization Settings", CustomFoxSettingsPage);
             addPageButton("Race Mode Settings", RaceSettingsPage);
+            addPageButton("Music Shuffle Settings", MusicSettingsPage);
             addPageButton("Other Settings", OtherSettingsPage);
         }
 
@@ -133,6 +134,7 @@ namespace TunicRandomizer {
 
         public static void EnemyTogglesPage() {
             OptionsGUI OptionsGUI = GameObject.FindObjectOfType<OptionsGUI>();
+            OptionsGUI.setHeading("Enemy Toggles");
 
             Action<int, bool> toggleAllEnemies = (int index, bool toggle) => {
                 GameObject.FindObjectsOfType<OptionsGUIMultiSelect>().ToList().ForEach((button) => {
@@ -205,28 +207,83 @@ namespace TunicRandomizer {
             OptionsGUI.addToggle("More Skulls", "Off", "On", TunicRandomizer.Settings.MoreSkulls ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleMoreSkulls);
             OptionsGUI.addToggle("Arachnophobia Mode", "Off", "On", TunicRandomizer.Settings.ArachnophobiaMode ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleArachnophobiaMode);
             OptionsGUI.addToggle("Holy Cross DDR", "Off", "On", TunicRandomizer.Settings.HolyCrossVisualizer ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)ToggleHolyCrossViewer);
-            OptionsGUI.addToggle("Music Shuffle", "Off", "On", TunicRandomizer.Settings.MusicShuffle ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)((int index) => { TunicRandomizer.Settings.MusicShuffle = !TunicRandomizer.Settings.MusicShuffle; SaveSettings(); }));
-            addPageButton("Jukebox", JukeboxPage);
             if (SecretMayor.shouldBeActive || SecretMayor.isCorrectDate()) {
                 OptionsGUI.addToggle("Mr Mayor", "Off", "On", SecretMayor.shouldBeActive ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)SecretMayor.ToggleMayorSecret);
             }
         }
 
+        public static void MusicSettingsPage() {
+            OptionsGUI OptionsGUI = GameObject.FindObjectOfType<OptionsGUI>();
+            OptionsGUI.setHeading("Music Shuffle");
+            OptionsGUI.addToggle("Music Shuffle", "Off", "On", TunicRandomizer.Settings.MusicShuffle ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)((int index) => { TunicRandomizer.Settings.MusicShuffle = !TunicRandomizer.Settings.MusicShuffle; SaveSettings(); }));
+            OptionsGUI.addToggle("Seeded Music", "Off", "On", TunicRandomizer.Settings.SeededMusic ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)((int index) => { TunicRandomizer.Settings.SeededMusic = !TunicRandomizer.Settings.SeededMusic; SaveSettings(); }));
+            addPageButton("Music Toggles", MusicTogglesPage);
+            addPageButton("Jukebox", JukeboxPage);
+        }
+
+        public static void MusicTogglesPage() {
+            OptionsGUI OptionsGUI = GameObject.FindObjectOfType<OptionsGUI>();
+            OptionsGUI.setHeading("Music Toggles");
+
+            Action<int, bool> toggleAllSongs = (int index, bool toggle) => {
+                GameObject.FindObjectsOfType<OptionsGUIMultiSelect>().ToList().ForEach((button) => {
+                    button.SelectIndex(index);
+                    TunicRandomizer.Settings.MusicToggles[button.leftAlignedText.text] = toggle;
+                });
+                SaveSettings();
+            };
+
+            OptionsGUI.addButton("Toggle All Tracks ON", (Action)(() => {
+                toggleAllSongs(1, true);
+            }));
+            OptionsGUI.addButton("Toggle All Tracks OFF", (Action)(() => {
+                toggleAllSongs(0, false);
+            }));
+
+            OptionsGUI.addButton("Randomize All", (Action)(() => {
+                System.Random random = new System.Random();
+                GameObject.FindObjectsOfType<OptionsGUIMultiSelect>().ToList().ForEach((button) => {
+                    int selection = random.Next(2);
+                    button.SelectIndex(selection);
+                    TunicRandomizer.Settings.MusicToggles[button.leftAlignedText.text] = selection == 1;
+                }); SaveSettings();
+            }));
+            Dictionary<string, Action<int>> toggles = new Dictionary<string, Action<int>>();
+            foreach (string track in MusicShuffler.Tracks.Keys) {
+                toggles.Add(track, (int index) => {
+                    TunicRandomizer.Settings.MusicToggles[track] = !TunicRandomizer.Settings.MusicToggles[track];
+                    SaveSettings();
+                });
+            }
+            foreach (string track in MusicShuffler.Tracks.Keys) {
+                OptionsGUI.addToggle(track, "Off", "On", TunicRandomizer.Settings.MusicToggles[track] ? 1 : 0, (OptionsGUIMultiSelect.MultiSelectAction)toggles[track]);
+            }
+        }
+
         public static void JukeboxPage() {
             OptionsGUI OptionsGUI = GameObject.FindObjectOfType<OptionsGUI>();
-            OptionsGUI.setHeading("Music");
+            OptionsGUI.setHeading("Jukebox");
 
             foreach (KeyValuePair<string, EventReference> pair in MusicShuffler.Tracks) {
                 OptionsGUI.addButton(pair.Key, 
                     (Action)(() => {
-                        MusicManager.Stop();
+                        if (pair.Value.Guid.ToString() == MusicManager.playingEventRef.Guid.ToString()) {
+                            MusicManager.StopImmediate();
+                        } else {
+                            MusicManager.Stop();
+                        }
                         MusicManager.PlayNewTrackIfDifferent(pair.Value);
                         MusicShuffler.instance.TimeSinceMusicStart = Time.realtimeSinceStartup;
                         if (MusicShuffler.TrackParams.ContainsKey(pair.Key)) {
                             foreach ((string, int) param in MusicShuffler.TrackParams[pair.Key]) {
-                                TunicLogger.LogInfo("queueing " + param.Item1 + " " + param.Item2);
                                 MusicShuffler.instance.paramsToSetRealtime.Enqueue(param);
                             }
+                        }
+                        if (pair.Key == "Cube Cave" && GameObject.FindObjectOfType<RotatingCubeClue>() == null && GameObject.FindObjectOfType<PlayMusicOnLoad>() != null) {
+                            GameObject cube = new GameObject("cube for music track");
+                            cube.AddComponent<RotatingCubeClue>();
+                            cube.GetComponent<RotatingCubeClue>().sequence = "rrrruuuurrruuurruuru";
+                            cube.transform.parent = GameObject.FindObjectOfType<PlayMusicOnLoad>().transform;
                         }
                     }));
             }

--- a/src/Patches/PlayerCharacterPatches.cs
+++ b/src/Patches/PlayerCharacterPatches.cs
@@ -100,6 +100,15 @@ namespace TunicRandomizer {
                 PaletteEditor.LoadCustomTexture();
             }
 
+            if (Input.GetKeyDown(KeyCode.Alpha7)) {
+                /*                MusicManager.PlayNewTrackIfDifferent(MusicRandomizer.sceneMusicGuids.Values.ToList()[index]);
+                                TunicLogger.LogInfo("manually playing track " + MusicRandomizer.sceneMusicGuids.Keys.ToList()[index] + " " + MusicRandomizer.sceneMusicGuids.Values.ToList()[index].Guid.ToString());
+                                index++;*/
+            }
+            if (Input.GetKeyDown(KeyCode.Alpha8)) {
+
+                MusicManager.SetParam("zig_3_location_index", 3);
+            }
             if (StungByBee) {
                 __instance.gameObject.transform.Find("Fox/root/pelvis/chest/head").localScale = new Vector3(3f, 3f, 3f);
             }
@@ -359,6 +368,8 @@ namespace TunicRandomizer {
             List<MagicSpell> spells = __instance.spells.ToList();
             spells.Reverse();
             __instance.spells = spells.ToArray();
+/*            MusicManager.SetParam("zig_3_location_index", 2);
+            MusicManager.SetParam("zig_3_location_index", 3);*/
         }
 
         private static void PlayerCharacter_Start_SinglePlayerSetup() {

--- a/src/Patches/PlayerCharacterPatches.cs
+++ b/src/Patches/PlayerCharacterPatches.cs
@@ -100,15 +100,6 @@ namespace TunicRandomizer {
                 PaletteEditor.LoadCustomTexture();
             }
 
-            if (Input.GetKeyDown(KeyCode.Alpha7)) {
-                /*                MusicManager.PlayNewTrackIfDifferent(MusicRandomizer.sceneMusicGuids.Values.ToList()[index]);
-                                TunicLogger.LogInfo("manually playing track " + MusicRandomizer.sceneMusicGuids.Keys.ToList()[index] + " " + MusicRandomizer.sceneMusicGuids.Values.ToList()[index].Guid.ToString());
-                                index++;*/
-            }
-            if (Input.GetKeyDown(KeyCode.Alpha8)) {
-
-                MusicManager.SetParam("zig_3_location_index", 3);
-            }
             if (StungByBee) {
                 __instance.gameObject.transform.Find("Fox/root/pelvis/chest/head").localScale = new Vector3(3f, 3f, 3f);
             }
@@ -209,7 +200,7 @@ namespace TunicRandomizer {
                 PaletteEditor.FoxCape.GetComponent<CreatureMaterialManager>().UseSpecialGhostMat = __instance.transform.GetChild(1).GetComponent<CreatureMaterialManager>().UseSpecialGhostMat;
             }
 
-            if (SceneManager.GetActiveScene().name == "FinalBossBefriend" && GameObject.FindObjectOfType<HexagonQuestCutscene>() == null) {
+            if (SceneManager.GetActiveScene().name == "FinalBossBefriend" && GameObject.FindObjectOfType<HexagonQuestCutscene>() == null && SaveFile.GetInt(HexagonQuestEnabled) == 1) {
                 new GameObject("hex quest cutscene").gameObject.AddComponent<HexagonQuestCutscene>();
             }
 
@@ -368,8 +359,6 @@ namespace TunicRandomizer {
             List<MagicSpell> spells = __instance.spells.ToList();
             spells.Reverse();
             __instance.spells = spells.ToArray();
-/*            MusicManager.SetParam("zig_3_location_index", 2);
-            MusicManager.SetParam("zig_3_location_index", 3);*/
         }
 
         private static void PlayerCharacter_Start_SinglePlayerSetup() {

--- a/src/TunicRandomizer.cs
+++ b/src/TunicRandomizer.cs
@@ -44,6 +44,13 @@ namespace TunicRandomizer {
             ClassInjector.RegisterTypeInIl2Cpp<ToggleObjectByFuse>();
             ClassInjector.RegisterTypeInIl2Cpp<BossEnemy>();
 
+            ClassInjector.RegisterTypeInIl2Cpp<MusicShuffler>();
+            UnityEngine.Object.DontDestroyOnLoad(new GameObject("music shuffler", new Il2CppSystem.Type[]
+            {
+                Il2CppType.Of<MusicShuffler>()
+            }) {
+                hideFlags = HideFlags.HideAndDontSave
+            });
             ClassInjector.RegisterTypeInIl2Cpp<PaletteEditor>();
             UnityEngine.Object.DontDestroyOnLoad(new GameObject("palette editor gui", new Il2CppSystem.Type[]
             {
@@ -222,6 +229,9 @@ namespace TunicRandomizer {
             
             Harmony.Patch(AccessTools.Method(typeof(ConduitData), "IsFuseClosedByID"), new HarmonyMethod(AccessTools.Method(typeof(InteractionPatches), "ConduitData_IsFuseClosedByID_PrefixPatch")));
 
+            Harmony.Patch(AccessTools.Method(typeof(PlayMusicOnLoad), "Start"), null, new HarmonyMethod(AccessTools.Method(typeof(MusicShuffler), "PlayMusicOnLoad_Start_PostfixPatch")));
+            Harmony.Patch(AccessTools.Method(typeof(MusicManager), "SetParam"), null, new HarmonyMethod(AccessTools.Method(typeof(MusicShuffler), "MusicManager_PlayCuedTrack_PostfixPatch")));
+            
         }
     }
 }

--- a/src/TunicRandomizer.cs
+++ b/src/TunicRandomizer.cs
@@ -232,6 +232,7 @@ namespace TunicRandomizer {
             Harmony.Patch(AccessTools.Method(typeof(ConduitData), "IsFuseClosedByID"), new HarmonyMethod(AccessTools.Method(typeof(InteractionPatches), "ConduitData_IsFuseClosedByID_PrefixPatch")));
 
             Harmony.Patch(AccessTools.Method(typeof(PlayMusicOnLoad), "Start"), null, new HarmonyMethod(AccessTools.Method(typeof(MusicShuffler), "PlayMusicOnLoad_Start_PostfixPatch")));
+
             Harmony.Patch(AccessTools.Method(typeof(MusicManager), "SetParam"), null, new HarmonyMethod(AccessTools.Method(typeof(MusicShuffler), "MusicManager_PlayCuedTrack_PostfixPatch")));
             
         }


### PR DESCRIPTION
Adds a music shuffle option to the randomizer.
Plays a random music track upon entering a scene, with an option for it to be seeded per scene.
Includes a menu to toggle which tracks get to play, as well as a jukebox/sound test menu to play any track on demand.
Some songs are probably missing, including all nighttime tracks.