### PR TITLE
Fix the logic bug

### DIFF
--- a/src/Data/SaveFlags.cs
+++ b/src/Data/SaveFlags.cs
@@ -35,6 +35,7 @@ namespace TunicRandomizer {
         public const string MasklessLogic = "randomizer maskless logic enabled";
         public const string LanternlessLogic = "randomizer lanternless logic enabled";
         public const string LadderRandoEnabled = "randomizer ladder rando enabled";
+        public const string LaurelsLocation = "randomizer laurels location";
 
         // Special Flags
         public const string PlayerDeathCount = "randomizer death count";

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -181,9 +181,9 @@ namespace TunicRandomizer {
                 foreach (Reward item in ProgressionRewards) {
                     if (item.Name == "Hyperdash") {
                         foreach (Location location in InitialLocations) {
-                            if ((SaveFile.GetInt(SaveFlags.LaurelsLocation) == 1 && location.LocationId == "Well Reward (6 Coins)")
-                                || (SaveFile.GetInt(SaveFlags.LaurelsLocation) == 2 && location.LocationId == "Well Reward (10 Coins)")
-                                || (SaveFile.GetInt(SaveFlags.LaurelsLocation) == 3 && location.LocationId == "waterfall")) {
+                            if ((location.LocationId == "Well Reward (6 Coins)" && SaveFile.GetInt(SaveFlags.LaurelsLocation) == 1)
+                                || (location.LocationId == "Well Reward (10 Coins)" && SaveFile.GetInt(SaveFlags.LaurelsLocation) == 2)
+                                || (location.LocationId == "waterfall" && SaveFile.GetInt(SaveFlags.LaurelsLocation) == 3)) {
                                 string DictionaryId = $"{location.LocationId} [{location.SceneName}]";
                                 Check Check = new Check(item, location);
                                 ProgressionLocations.Add(DictionaryId, Check);

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -82,9 +82,11 @@ namespace TunicRandomizer {
             List<Reward> InitialRewards = new List<Reward>();
             List<Location> InitialLocations = new List<Location>();
             List<Check> Hexagons = new List<Check>();
-            Check Laurels = new Check();
+            // the list of progression items
             List<Reward> ProgressionRewards = new List<Reward>();
+            // inventory of progression items that have not been placed yet
             Dictionary<string, int> UnplacedInventory = new Dictionary<string, int>();
+            // locations that progression is placed at
             Dictionary<string, Check> ProgressionLocations = new Dictionary<string, Check> { };
 
             int GoldHexagonsAdded = 0;
@@ -174,28 +176,14 @@ namespace TunicRandomizer {
                 }
             }
 
-            // pre-place laurels in ProgressionRewards, so that fill can collect it as needed
+            // pre-place laurels in ProgressionLocations, so that fill can collect it as needed
             if (SaveFile.GetInt("randomizer laurels location") != 0) {
                 foreach (Reward item in ProgressionRewards) {
                     if (item.Name == "Hyperdash") {
                         foreach (Location location in InitialLocations) {
-                            if (SaveFile.GetInt("randomizer laurels location") == 1 && location.LocationId == "Well Reward (6 Coins)") {
-                                string DictionaryId = $"{location.LocationId} [{location.SceneName}]";
-                                Check Check = new Check(item, location);
-                                ProgressionLocations.Add(DictionaryId, Check);
-                                InitialLocations.Remove(location);
-                                ProgressionRewards.Remove(item);
-                                break;
-                            }
-                            if (SaveFile.GetInt("randomizer laurels location") == 2 && location.LocationId == "Well Reward (10 Coins)") {
-                                string DictionaryId = $"{location.LocationId} [{location.SceneName}]";
-                                Check Check = new Check(item, location);
-                                ProgressionLocations.Add(DictionaryId, Check);
-                                InitialLocations.Remove(location);
-                                ProgressionRewards.Remove(item);
-                                break;
-                            }
-                            if (SaveFile.GetInt("randomizer laurels location") == 3 && location.LocationId == "waterfall") {
+                            if ((SaveFile.GetInt("randomizer laurels location") == 1 && location.LocationId == "Well Reward (6 Coins)")
+                                || (SaveFile.GetInt("randomizer laurels location") == 2 && location.LocationId == "Well Reward (10 Coins)")
+                                || (SaveFile.GetInt("randomizer laurels location") == 3 && location.LocationId == "waterfall")) {
                                 string DictionaryId = $"{location.LocationId} [{location.SceneName}]";
                                 Check Check = new Check(item, location);
                                 ProgressionLocations.Add(DictionaryId, Check);
@@ -244,6 +232,7 @@ namespace TunicRandomizer {
                     UnplacedInventory.Remove(itemName);
                 }
 
+                // clear the inventory we use to determine access, put the Overworld region, unplaced items, and precollected items in it
                 FullInventory.Clear();
                 FullInventory.Add("Overworld", 1);
                 foreach (KeyValuePair<string, int> unplacedItem in UnplacedInventory) {
@@ -251,6 +240,7 @@ namespace TunicRandomizer {
                 }
                 AddListToDict(FullInventory, PrecollectedItems);
 
+                // cache for picking up items during fill
                 checksAlreadyAdded.Clear();
 
                 // fill method: reverse fill and anything you can get with your remaining inventory is assumed to be in your inventory for the purpose of placing the next item
@@ -306,6 +296,7 @@ namespace TunicRandomizer {
 
 
                 // this is for testing fill, ignore if not testing
+                // using a full inventory of items, checks whether each location is reachable, and prints an error if any aren't
                 // change the testLocations bool to true to have it to test whether all locations can be reached
                 if (testBool) {
                     TunicLogger.LogInfo("test starts here");
@@ -326,9 +317,8 @@ namespace TunicRandomizer {
 
                     AddListToDict(testFullInventory, PrecollectedItems);
 
-                    if (SaveFile.GetInt("randomizer entrance rando enabled") == 1) {
+                    if (SaveFile.GetInt(SaveFlags.EntranceRando) == 1) {
                         // this should keep looping until every portal either doesn't give a reward, or has already given its reward
-
                         testFullInventory.Clear();
                         testFullInventory.Add("Overworld", 1);
                         foreach (KeyValuePair<string, int> unplacedItem in testUnplacedInventory) {

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -177,13 +177,13 @@ namespace TunicRandomizer {
             }
 
             // pre-place laurels in ProgressionLocations, so that fill can collect it as needed
-            if (SaveFile.GetInt("randomizer laurels location") != 0) {
+            if (SaveFile.GetInt(SaveFlags.LaurelsLocation) != 0) {
                 foreach (Reward item in ProgressionRewards) {
                     if (item.Name == "Hyperdash") {
                         foreach (Location location in InitialLocations) {
-                            if ((SaveFile.GetInt("randomizer laurels location") == 1 && location.LocationId == "Well Reward (6 Coins)")
-                                || (SaveFile.GetInt("randomizer laurels location") == 2 && location.LocationId == "Well Reward (10 Coins)")
-                                || (SaveFile.GetInt("randomizer laurels location") == 3 && location.LocationId == "waterfall")) {
+                            if ((SaveFile.GetInt(SaveFlags.LaurelsLocation) == 1 && location.LocationId == "Well Reward (6 Coins)")
+                                || (SaveFile.GetInt(SaveFlags.LaurelsLocation) == 2 && location.LocationId == "Well Reward (10 Coins)")
+                                || (SaveFile.GetInt(SaveFlags.LaurelsLocation) == 3 && location.LocationId == "waterfall")) {
                                 string DictionaryId = $"{location.LocationId} [{location.SceneName}]";
                                 Check Check = new Check(item, location);
                                 ProgressionLocations.Add(DictionaryId, Check);

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -198,11 +198,15 @@ namespace TunicRandomizer {
                 TunicPortals.RandomizedPortals = TunicPortals.VanillaPortals();
             }
 
+            // used in fill to keep checks that you've re-collected items from from being collected again
+            List<Check> checksAlreadyAdded = new List<Check>();
+
             // full inventory is to separate out "fake" items from real ones
             Dictionary<string, int> FullInventory = new Dictionary<string, int>();
-
+            int iteration_number = 0;
             // put progression items in locations
             foreach (Reward item in ProgressionRewards.OrderBy(r => random.Next())) {
+                iteration_number++;
                 // pick an item
                 string itemName = ItemLookup.FairyLookup.Keys.Contains(item.Name) ? "Fairy" : item.Name;
                 // remove item from inventory for reachability checks
@@ -220,9 +224,15 @@ namespace TunicRandomizer {
                 }
                 AddListToDict(FullInventory, PrecollectedItems);
 
+                checksAlreadyAdded.Clear();
+
                 // fill method: reverse fill and anything you can get with your remaining inventory is assumed to be in your inventory for the purpose of placing the next item
                 while (true) {
-                    int start_count = FullInventory.Count;
+                    // start count is the quantity of items in full inventory. If this stays the same between loops, then you are done getting items
+                    int start_count = 0;
+                    foreach (int count in FullInventory.Values) {
+                        start_count += count;
+                    }
 
                     // do some shenanigans to decide whether you have laurels accessible
                     if (!FullInventory.ContainsKey("Hyperdash") && (SaveFile.GetInt("randomizer laurels location") == 1 && FullInventory["Trinket Coin"] >= 6)
@@ -234,6 +244,7 @@ namespace TunicRandomizer {
 
                     // fill up our FullInventory with regions until we stop getting new regions -- these are the regions we can currently access
                     while (true) {
+                        // since regions always have a count of 1, we can just use .count instead of counting up all the values
                         int start_num = FullInventory.Count;
                         FullInventory = TunicPortals.UpdateReachableRegions(FullInventory);
                         foreach (PortalCombo portalCombo in TunicPortals.RandomizedPortals.Values) {
@@ -244,19 +255,36 @@ namespace TunicRandomizer {
                         }
                     }
 
+                    // for debugging to check inventory item counts
+                    //TunicLogger.LogInfo("iteration number is " + iteration_number.ToString());
+                    //TunicLogger.LogInfo("item being placed is " + item.Name);
+                    //TunicLogger.LogInfo("Full Inventory is");
+                    //foreach (string iname in FullInventory.Keys) {
+                    //    TunicLogger.LogInfo(iname + ": " + FullInventory[iname].ToString());
+                    //}
+
                     // pick up all items you can reach with your current inventory
                     foreach (Check placedLocation in ProgressionLocations.Values) {
-                        if (placedLocation.Location.reachable(FullInventory)) {
+                        if (placedLocation.Location.reachable(FullInventory) && !checksAlreadyAdded.Contains(placedLocation)) {
+                            //TunicLogger.LogInfo("Location " + Locations.LocationIdToDescription[$"{placedLocation.Location.LocationId} [{placedLocation.Location.SceneName}]"] + " is reachable");
+                            //TunicLogger.LogInfo("Adding " + placedLocation.Reward.Name + " to inventory");
                             string item_name = ItemLookup.FairyLookup.Keys.Contains(placedLocation.Reward.Name) ? "Fairy" : placedLocation.Reward.Name;
                             AddStringToDict(FullInventory, item_name);
+                            checksAlreadyAdded.Add(placedLocation);
                         }
                     }
 
+                    int end_count = 0;
+                    foreach (int count in FullInventory.Values) {
+                        end_count += count;
+                    }
+
                     // if these two are equal, then we've gotten everything we have access to
-                    if (start_count == FullInventory.Count) {
+                    if (start_count == end_count) {
                         break;
                     }
                 }
+
 
                 // this is for testing fill, ignore if not testing
                 // change the testLocations bool to true to have it to test whether all locations can be reached
@@ -312,6 +340,7 @@ namespace TunicRandomizer {
                     TunicLogger.LogInfo("test ends here");
                     testBool = false;
                 }
+
 
                 // pick a location
                 int l;

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -261,14 +261,6 @@ namespace TunicRandomizer {
                         start_count += count;
                     }
 
-                    // do some shenanigans to decide whether you have laurels accessible
-                    if (!FullInventory.ContainsKey("Hyperdash") && (SaveFile.GetInt("randomizer laurels location") == 1 && FullInventory["Trinket Coin"] >= 6)
-                        || (SaveFile.GetInt("randomizer laurels location") == 2 && FullInventory["Trinket Coin"] >= 10)
-                        || (SaveFile.GetInt("randomizer laurels location") == 3 && FullInventory.ContainsKey("Fairy") && FullInventory["Fairy"] >= 10 && FullInventory.ContainsKey("Secret Gathering Place"))) {
-                        // laurels location is on, and you have the required items to access it
-                        FullInventory.Add("Hyperdash", 1);
-                    }
-
                     // fill up our FullInventory with regions until we stop getting new regions -- these are the regions we can currently access
                     while (true) {
                         // since regions always have a count of 1, we can just use .count instead of counting up all the values


### PR DESCRIPTION
With the revised fill system, the generator "picks up" items in accessible locations with its current inventory, and keeps doing this until it gets no new items.

To do this, it checks which locations have already been placed, and if it is accessible, picks up its item. Unfortunately, we were not caching which locations were already picked up, so each iteration it would just keep picking up the same locations.

What this PR does:
- Makes a list to cache which locations have been picked up to avoid the bug.
- Revises the counter so that instead of counting how many keys are in the dictionary, it sums the values. So if you have 2 coins, then the next iteration you pick up 1 coin, it will do another iteration instead of stopping.
- If one of the laurels plando options is chosen, it adds the laurels to ProgressionLocations instead of its own unique rewards thing, and then pulls out the hacky jank that was used to see if you should have laurels access (since the collect stuff from the world should just work if you place laurels in a spot).