### PR TITLE
Update upper zig first chest logic

### DIFF
--- a/src/Data/ItemListJson.cs
+++ b/src/Data/ItemListJson.cs
@@ -4534,6 +4534,11 @@
                         {
                             ""Rooted Ziggurat Upper Front"": 1,
                             ""Sword"": 1
+                        },
+                        {
+                            ""Rooted Ziggurat Upper Front"": 1,
+                            ""Techbow"": 1,
+                            ""Hyperdash"": 1
                         }
                     ]
                 }


### PR DESCRIPTION
Updates the logic so you require either a sword or both wand and laurels. While you can get it with just laurels, you will then be unable to get through the rest of upper zig. While I could make it so the rule is different in ER, I'm not gonna because that requires some fake item to say ER is on, and I'm not gonna do that for an alt rule for one check