### PR TITLE
Fix lag issues in overworld ladder rando by moving switches

### DIFF
--- a/src/Util/ToggleLadderByLadderItem.cs
+++ b/src/Util/ToggleLadderByLadderItem.cs
@@ -27,7 +27,12 @@ namespace TunicRandomizer {
             }
 
             foreach (GameObject gameObject in optionalObjectsToDisable) {
-                gameObject.SetActive(ladderItem.Quantity > 0);
+                if(ladderItem.Quantity == 0 && gameObject.name.Contains("Stone Switch")) {
+                    //instead of removing the switches (causing a ton of lag when an every-frame coroutine tries to run on them), lets just move them really far away
+                    gameObject.transform.position = new Vector3(10000, 10000, 10000);
+                } else {
+                    gameObject.SetActive(ladderItem.Quantity > 0);
+                }
             }
 
             for (int i = 0; i < this.transform.childCount; i++) {


### PR DESCRIPTION
Currently, when starting a game with Ladder Shuffle enabled, the two stone Switches in the overworld are disabled to prevent the player from accessing those shortcuts without finding the ladder item.  This seems to cause an issue with the main game loop on this map, as every frame error will be emitted from failing to start a Coroutine involving these two stone switches.  This becomes apparent to users in the form of noticeable hitching/stuttering when the player is in the overworld.

This workaround checks the logic in the `ToggleLadderByItem` behavior related to handling objects identified in the `optionalObjectsToDisable` property, and in the case of the Stone Switches, it moves them _very far_ out of the play area instead of disabling them.  The result is elimination of the hitching (and a much cleaner console/log output) while the player is on the overworld map by allowing the coroutines to property initialize.