### PR TITLE
Make shop orientation match entrance orientation in ER

### DIFF
--- a/src/Data/Portal.cs
+++ b/src/Data/Portal.cs
@@ -10,6 +10,7 @@ namespace TunicRandomizer {
         public string DestinationTag { get; set; }
         public string SceneDestinationTag { get; set; }
         public string DestinationSceneTag { get; set; }
+        public int Direction { get; set; }
 
         public Portal(string name, string destination, string tag, string scene, string region) {
             Name = name;
@@ -20,6 +21,18 @@ namespace TunicRandomizer {
             DestinationTag = (Destination + Tag);
             SceneDestinationTag = (Scene + ", " + DestinationTag);
             DestinationSceneTag = (Destination + ", " + Scene + Tag);  // for finding the vanilla connection
+        }
+
+        public Portal(string name, string destination, string tag, string scene, string region, int direction) {
+            Name = name;
+            Destination = destination;
+            Tag = tag;
+            Scene = scene;
+            Region = region;
+            DestinationTag = (Destination + Tag);
+            SceneDestinationTag = (Scene + ", " + DestinationTag);
+            DestinationSceneTag = (Destination + ", " + Scene + Tag);
+            Direction = direction;
         }
 
         public bool CanReach(Dictionary<string, int> inventory) {

--- a/src/Data/PortalCombo.cs
+++ b/src/Data/PortalCombo.cs
@@ -43,5 +43,14 @@ namespace TunicRandomizer {
             }
             return inventory;
         }
+
+        // check if this portal is oriented such that we should use the left-to-right shop look
+        public bool FlippedShop() {
+            if (Portal2.Name == "Shop Portal" && (Portal1.Direction == (int)TunicPortals.PDir.EAST || Portal1.Direction == (int)TunicPortals.PDir.SOUTH)) {
+                return true;
+            }
+            return false;
+        }
+
     }
 }


### PR DESCRIPTION
If the entrance to a shop is east or south (meaning you walk east or walk south to enter it), it will now have its flipped orientation.