### PR TITLE
Fix potion cost

### DIFF
--- a/src/Patches/ItemPatches.cs
+++ b/src/Patches/ItemPatches.cs
@@ -1,8 +1,6 @@
 ﻿using Archipelago.MultiClient.Net.Models;
-using FMOD;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Design;
 using System.Globalization;
 using System.Linq;
 using UnityEngine;

--- a/src/Patches/ItemPatches.cs
+++ b/src/Patches/ItemPatches.cs
@@ -896,7 +896,6 @@ namespace TunicRandomizer {
             Inventory.GetItemByName("Hyperdash").Quantity = 1;
             Inventory.GetItemByName("Key (House)").Quantity = 1;
             Inventory.GetItemByName("Vault Key (Red)").Quantity = 1;
-            Inventory.GetItemByName("Upgrade Offering - PotionEfficiency Swig - Ash").Quantity = 8;
         }
     }
 }

--- a/src/Patches/ItemPatches.cs
+++ b/src/Patches/ItemPatches.cs
@@ -1,6 +1,8 @@
 ﻿using Archipelago.MultiClient.Net.Models;
+using FMOD;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.Design;
 using System.Globalization;
 using System.Linq;
 using UnityEngine;
@@ -862,7 +864,14 @@ namespace TunicRandomizer {
         }
 
         public static void OfferingItem_PriceForNext_PostfixPatch(OfferingItem __instance, ref int __result) {
-            __result -= Mathf.RoundToInt(__instance.priceIncreasePerLevelup * (float)ItemLookup.BonusUpgrades.Where(bonus => Inventory.GetItemByName(bonus.Key).Quantity > 0 && bonus.Value.LevelUp == __instance.upgradeItemReceived.name).Count());
+            int free_upgrade_count = ItemLookup.BonusUpgrades.Where(bonus => Inventory.GetItemByName(bonus.Key).Quantity > 0 && bonus.Value.LevelUp == __instance.upgradeItemReceived.name).Count();
+            // potion upgrades cost 100 for the first, 300 for the second, 1000 for the third, and +200 for each one after the third
+            if (__instance.name == "Upgrade Offering - PotionEfficiency Swig - Ash" 
+                && __result >= 1000 && free_upgrade_count >= (__result - 800) / 200) {
+                __result -= Mathf.RoundToInt(500 + 200 * free_upgrade_count);
+            } else {
+                __result -= Mathf.RoundToInt(__instance.priceIncreasePerLevelup * (float)free_upgrade_count);
+            }
         }
 
         public static bool FairyCollection_getFairyCount_PrefixPatch(FairyCollection __instance, ref int __result) {
@@ -887,6 +896,7 @@ namespace TunicRandomizer {
             Inventory.GetItemByName("Hyperdash").Quantity = 1;
             Inventory.GetItemByName("Key (House)").Quantity = 1;
             Inventory.GetItemByName("Vault Key (Red)").Quantity = 1;
+            Inventory.GetItemByName("Upgrade Offering - PotionEfficiency Swig - Ash").Quantity = 8;
         }
     }
 }


### PR DESCRIPTION
With that newer thing to make upgrades not go up in price if you get free upgrades, the potion upgrades didn't get the correct numbers since they have a weird price jump.
First potion upgrade costs 100, second is 300, third is 1000, fourth and higher and +200 each over the third.

But with the mod, currently if you get 2 free upgrades, your first potion upgrade (to get to level 4) costs 600, which is 500 more than it should be.