### PR TITLE
Fix a couple logic bugs

### DIFF
--- a/src/Data/GrassReqs.json
+++ b/src/Data/GrassReqs.json
@@ -1244,5 +1244,41 @@
       "West Garden",
       "Hyperdash"
     ]
+  ],
+  "grass swamp (991)~(34.5, 8.3, 31.8)": [
+    [
+      "Back of Swamp Laurels Area",
+      "Hyperdash"
+    ]
+  ],
+  "grass swamp (992)~(34.5, 8.0, 30.8)": [
+    [
+      "Back of Swamp Laurels Area",
+      "Hyperdash"
+    ]
+  ],
+  "grass swamp (989)~(35.5, 8.0, 30.8)": [
+    [
+      "Back of Swamp Laurels Area",
+      "Hyperdash"
+    ]
+  ],
+  "grass swamp (990)~(35.5, 8.0, 31.8)": [
+    [
+      "Back of Swamp Laurels Area",
+      "Hyperdash"
+    ]
+  ],
+  "grass swamp (995)~(32.5, 8.3, 31.8)": [
+    [
+      "Back of Swamp Laurels Area",
+      "Hyperdash"
+    ]
+  ],
+  "grass swamp (994)~(33.5, 8.0, 31.8)": [
+    [
+      "Back of Swamp Laurels Area",
+      "Hyperdash"
+    ]
   ]
 }

--- a/src/Data/ItemListJson.cs
+++ b/src/Data/ItemListJson.cs
@@ -2339,8 +2339,17 @@
                     ""Position"": ""(119.7, 92.8, -84.0)"",
                     ""Requirements"": [
                         {
-                            ""Library Lab"": 1
-                        }
+                            ""Library Lab"": 1,
+                            ""Stick"": 1,
+                        },
+                        {
+                            ""Library Lab"": 1,
+                            ""Techbow"": 1,
+                        },
+                        {
+                            ""Library Lab"": 1,
+                            ""Gun"": 1,
+                        },
                     ]
                 }
             },
@@ -2357,8 +2366,17 @@
                     ""Position"": ""(129.1, 92.8, -68.7)"",
                     ""Requirements"": [
                         {
-                            ""Library Lab"": 1
-                        }
+                            ""Library Lab"": 1,
+                            ""Stick"": 1,
+                        },
+                        {
+                            ""Library Lab"": 1,
+                            ""Techbow"": 1,
+                        },
+                        {
+                            ""Library Lab"": 1,
+                            ""Gun"": 1,
+                        },
                     ]
                 }
             },
@@ -2375,8 +2393,17 @@
                     ""Position"": ""(160.1, 92.8, -74.9)"",
                     ""Requirements"": [
                         {
-                            ""Library Lab"": 1
-                        }
+                            ""Library Lab"": 1,
+                            ""Stick"": 1,
+                        },
+                        {
+                            ""Library Lab"": 1,
+                            ""Techbow"": 1,
+                        },
+                        {
+                            ""Library Lab"": 1,
+                            ""Gun"": 1,
+                        },
                     ]
                 }
             },
@@ -3888,8 +3915,13 @@
                     ""Position"": ""(57.5, 26.0, 43.8)"",
                     ""Requirements"": [
                         {
-                            ""Fortress Leaf Piles"": 1
-                        }
+                            ""Fortress Leaf Piles"": 1,
+                            ""Stick"",
+                        },
+                        {
+                            ""Fortress Leaf Piles"": 1,
+                            ""Stundagger"",
+                        },
                     ]
                 }
             },

--- a/src/Data/ItemListJson.cs
+++ b/src/Data/ItemListJson.cs
@@ -2340,16 +2340,16 @@
                     ""Requirements"": [
                         {
                             ""Library Lab"": 1,
-                            ""Stick"": 1,
+                            ""Stick"": 1
                         },
                         {
                             ""Library Lab"": 1,
-                            ""Techbow"": 1,
+                            ""Techbow"": 1
                         },
                         {
                             ""Library Lab"": 1,
-                            ""Gun"": 1,
-                        },
+                            ""Gun"": 1
+                        }
                     ]
                 }
             },
@@ -2367,16 +2367,16 @@
                     ""Requirements"": [
                         {
                             ""Library Lab"": 1,
-                            ""Stick"": 1,
+                            ""Stick"": 1
                         },
                         {
                             ""Library Lab"": 1,
-                            ""Techbow"": 1,
+                            ""Techbow"": 1
                         },
                         {
                             ""Library Lab"": 1,
-                            ""Gun"": 1,
-                        },
+                            ""Gun"": 1
+                        }
                     ]
                 }
             },
@@ -2394,16 +2394,16 @@
                     ""Requirements"": [
                         {
                             ""Library Lab"": 1,
-                            ""Stick"": 1,
+                            ""Stick"": 1
                         },
                         {
                             ""Library Lab"": 1,
-                            ""Techbow"": 1,
+                            ""Techbow"": 1
                         },
                         {
                             ""Library Lab"": 1,
-                            ""Gun"": 1,
-                        },
+                            ""Gun"": 1
+                        }
                     ]
                 }
             },
@@ -3916,12 +3916,12 @@
                     ""Requirements"": [
                         {
                             ""Fortress Leaf Piles"": 1,
-                            ""Stick"",
+                            ""Stick"": 1
                         },
                         {
                             ""Fortress Leaf Piles"": 1,
-                            ""Stundagger"",
-                        },
+                            ""Stundagger"": 1
+                        }
                     ]
                 }
             },

--- a/src/Patches/ERData.cs
+++ b/src/Patches/ERData.cs
@@ -3826,6 +3826,7 @@ namespace TunicRandomizer {
                     },
                 }
             },
+
             {
                 "Library Lab Lower",
                 new Dictionary<string, List<List<string>>> {
@@ -3857,7 +3858,7 @@ namespace TunicRandomizer {
                         "Library Lab on Portal Pad",
                         new List<List<string>> {
                             new List<string> {
-                                "12",
+                                "Ladders in Library",
                             },
                         }
                     },
@@ -3901,12 +3902,6 @@ namespace TunicRandomizer {
                     {
                         "Library Lab on Portal Pad",
                         new List<List<string>> {
-                            new List<string> {
-                                "Ladders in Library",
-                            },
-                            new List<string> {
-                                "Hyperdash",
-                            },
                         }
                     },
                 }
@@ -3924,6 +3919,7 @@ namespace TunicRandomizer {
                     },
                 }
             },
+
             {
                 "Fortress Exterior from East Forest",
                 new Dictionary<string, List<List<string>>> {


### PR DESCRIPTION
Fix some grass in the Swamp incorrectly not requiring Laurels.
Fix a couple region connections in the Library Lab, which I don't actually think create a logic bug, but it's clearly not written correctly so it's fixed now.
Also add logic for the glass page prisons in the library (stick, gun, or wand)
Also add logic for the leaf piles in Dusty (stick or dagger)