### PR TITLE
Give torch on any ice grappling option

### DIFF
--- a/src/Patches/PlayerCharacterPatches.cs
+++ b/src/Patches/PlayerCharacterPatches.cs
@@ -648,7 +648,7 @@ namespace TunicRandomizer {
                     }
                 }
                 if (slotData.TryGetValue("ice_grappling", out var iceGrappling)) {
-                    if (iceGrappling.ToString() == "2" || iceGrappling.ToString() == "3") {
+                    if (iceGrappling.ToString() != "0") {
                         Inventory.GetItemByName("Torch").Quantity = 1;
                     }
                 }


### PR DESCRIPTION
Ice grappling down from the pillars in swamp to main swamp without the ladder to swamp is a softlock if you don't have laurels zips on. I say screw it, let's just give them the torch to make our lives easier.