### PR TITLE
Fix seeking spell logic for entrance seeking in a scene that has checks left that you can't get to

### DIFF
--- a/src/Patches/ERData.cs
+++ b/src/Patches/ERData.cs
@@ -6,6 +6,7 @@ using UnityEngine.SceneManagement;
 namespace TunicRandomizer {
     public class ERData {
         public static Dictionary<string, PortalCombo> RandomizedPortals = new Dictionary<string, PortalCombo>();
+        public static Dictionary<string, PortalCombo> VanillaPortals = new Dictionary<string, PortalCombo>();
         public static Dictionary<string, Dictionary<string, List<List<string>>>> ModifiedTraversalReqs = new Dictionary<string, Dictionary<string, List<List<string>>>>();
 
         // the direction you move while entering the portal

--- a/src/Patches/ERScripts.cs
+++ b/src/Patches/ERScripts.cs
@@ -174,7 +174,7 @@ namespace TunicRandomizer {
             return inventory;
         }
 
-        public static Dictionary<string, PortalCombo> VanillaPortals() {
+        public static void SetupVanillaPortals() {
             ModifiedTraversalReqs = TraversalReqs;
             Dictionary<string, PortalCombo> portalCombos = new Dictionary<string, PortalCombo>();
             Dictionary<Portal, Portal> portalPairs = new Dictionary<Portal, Portal>();
@@ -230,8 +230,7 @@ namespace TunicRandomizer {
                 portalCombos.Add(count.ToString(), new PortalCombo(portal2, portal1));
                 count++;
             }
-            // we don't need vanilla portals to be split into two dictionaries, since we aren't modifying the Portals themselves
-            return portalCombos;
+            ERData.VanillaPortals = portalCombos;
         }
 
         // create a list of all portals with their information loaded in, just a slightly expanded version of the above to include destinations
@@ -824,7 +823,7 @@ namespace TunicRandomizer {
                     continue;
                 }
                 // go through the list of randomized portals and see if the first portal matches the one we're looking at
-                foreach (KeyValuePair<string, PortalCombo> portalCombo in VanillaPortals()) {
+                foreach (KeyValuePair<string, PortalCombo> portalCombo in ERData.VanillaPortals) {
                     Portal portal1 = portalCombo.Value.Portal1;
                     Portal portal2 = portalCombo.Value.Portal2;
 

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -257,7 +257,7 @@ namespace TunicRandomizer {
             if (SaveFile.GetInt(EntranceRando) == 1) {
                 ERScripts.RandomizePortals(SaveFile.GetInt("seed"));
             } else {
-                ERData.RandomizedPortals = ERScripts.VanillaPortals();
+                ERData.RandomizedPortals = ERData.VanillaPortals;
             }
 
             // used in fill to keep checks that you've re-collected items from from being collected again
@@ -574,7 +574,7 @@ namespace TunicRandomizer {
         // in non-ER, we want the actual sphere 1
         public static Dictionary<string, int> GetSphereOne(Dictionary<string, int> startInventory = null) {
             Dictionary<string, int> Inventory = new Dictionary<string, int>() { { "Overworld", 1 } };
-            Dictionary<string, PortalCombo> vanillaPortals = ERScripts.VanillaPortals();
+            Dictionary<string, PortalCombo> vanillaPortals = ERData.VanillaPortals;
             if (startInventory == null) {
                 TunicUtils.AddListToDict(Inventory, PrecollectedItems);
             } else {
@@ -601,7 +601,7 @@ namespace TunicRandomizer {
             if (SaveFile.GetInt(EntranceRando) == 1) {
                 portalList = ERData.RandomizedPortals;
             } else {
-                portalList = ERScripts.VanillaPortals();
+                portalList = ERData.VanillaPortals;
             }
 
             while (true) {

--- a/src/Patches/PlayerCharacterPatches.cs
+++ b/src/Patches/PlayerCharacterPatches.cs
@@ -286,7 +286,7 @@ namespace TunicRandomizer {
                 ERScripts.ModifyPortals("Overworld Redux", sending: true);
                 GhostHints.SpawnTorchHintGhost();
             } else {
-                ERData.RandomizedPortals.Clear();
+                ERData.RandomizedPortals = ERScripts.VanillaPortals();
                 ERScripts.ModifyPortalNames("Overworld Redux");
             }
 

--- a/src/Patches/PlayerCharacterPatches.cs
+++ b/src/Patches/PlayerCharacterPatches.cs
@@ -286,7 +286,7 @@ namespace TunicRandomizer {
                 ERScripts.ModifyPortals("Overworld Redux", sending: true);
                 GhostHints.SpawnTorchHintGhost();
             } else {
-                ERData.RandomizedPortals = ERScripts.VanillaPortals();
+                ERData.RandomizedPortals = ERData.VanillaPortals;
                 ERScripts.ModifyPortalNames("Overworld Redux");
             }
 

--- a/src/Patches/QuickSettings.cs
+++ b/src/Patches/QuickSettings.cs
@@ -1009,7 +1009,6 @@ namespace TunicRandomizer {
                     });
                 }
             }
-            ERData.RandomizedPortals.Clear();
             return true;
         }
 

--- a/src/Patches/SceneLoaderPatches.cs
+++ b/src/Patches/SceneLoaderPatches.cs
@@ -526,7 +526,10 @@ namespace TunicRandomizer {
                 });
                 GhostHints.SpawnTorchHintGhost();
             } else {
-                ERData.RandomizedPortals = ERScripts.VanillaPortals();
+                if (ERData.VanillaPortals.Count == 0) {
+                    ERScripts.SetupVanillaPortals();
+                }
+                ERData.RandomizedPortals = ERData.VanillaPortals;
                 ERScripts.ModifyPortalNames(loadingScene.name);
             }
             ERScripts.MarkPortals();

--- a/src/Patches/SceneLoaderPatches.cs
+++ b/src/Patches/SceneLoaderPatches.cs
@@ -526,7 +526,7 @@ namespace TunicRandomizer {
                 });
                 GhostHints.SpawnTorchHintGhost();
             } else {
-                ERData.RandomizedPortals.Clear();
+                ERData.RandomizedPortals = ERScripts.VanillaPortals();
                 ERScripts.ModifyPortalNames(loadingScene.name);
             }
             ERScripts.MarkPortals();


### PR DESCRIPTION
It was checking RandomizedPortals, which was being cleared when you aren't in entrance rando instead of set to VanillaPortals