### PR TITLE
Require sword or wand for Monastery Front -> Back

### DIFF
--- a/src/Patches/ERData.cs
+++ b/src/Patches/ERData.cs
@@ -4325,6 +4325,12 @@ namespace TunicRandomizer {
                     {
                         "Monastery Back",
                         new List<List<string>> {
+                            new List<string> {
+                                "Techbow",
+                            },
+                            new List<string> {
+                                "Sword",
+                            },
                         }
                     },
                 }


### PR DESCRIPTION
Making the change on the AP side since I think it's sensible enough