### PR TITLE
Fix for extra shops

### DIFF
--- a/src/Data/ItemTracker.cs
+++ b/src/Data/ItemTracker.cs
@@ -225,7 +225,10 @@ namespace TunicRandomizer {
 
             Dictionary<string, List<string>> regionsToPortals = new Dictionary<string, List<string>>();
 
+            List<string> addedPortals = new List<string>();
+
             void addPortal(string portalName, string portalRegion) {
+                addedPortals.Add(portalName);
                 PortalCombo portalCombo = portalNameToPair[portalName];
                 string portalLine = portalCombo.Portal1.Name + ",-->,";
                 if (SaveFile.GetInt("randomizer entered portal " + portalName) == 1) {
@@ -247,6 +250,26 @@ namespace TunicRandomizer {
                     }
                 }
             }
+
+            // the sorting stuff above skips shops, and they're at the end anyway so let's just add them here
+            List<int> leftoverShopNums = new List<int>();
+            foreach (string portalName in allInUsePortalNames) {
+                if (!addedPortals.Contains(portalName)) {
+                    if (portalName.StartsWith("Shop")) {
+                        int shopNum = Convert.ToInt32(string.Concat(portalName.ToArray().Reverse().TakeWhile(char.IsNumber).Reverse()));
+                        leftoverShopNums.Add(shopNum);
+                    } else {
+                        TunicLogger.LogInfo($"Was missing {portalName} in ItemTracker.WriteEntranceFile, we should investigate this");
+                    }
+                }
+            }
+
+            leftoverShopNums.Sort();
+
+            foreach (int num in leftoverShopNums) {
+                addPortal($"Shop Portal {num}", "Shop");
+            }
+
             fileContents = "From,,To\n";
             foreach (KeyValuePair<string, List<string>> pair in regionsToPortals) {
                 fileContents += pair.Key + ",,\n";

--- a/src/Data/ItemTracker.cs
+++ b/src/Data/ItemTracker.cs
@@ -252,22 +252,9 @@ namespace TunicRandomizer {
             }
 
             // the sorting stuff above skips shops, and they're at the end anyway so let's just add them here
-            List<int> leftoverShopNums = new List<int>();
-            foreach (string portalName in allInUsePortalNames) {
-                if (!addedPortals.Contains(portalName)) {
-                    if (portalName.StartsWith("Shop")) {
-                        int shopNum = Convert.ToInt32(string.Concat(portalName.ToArray().Reverse().TakeWhile(char.IsNumber).Reverse()));
-                        leftoverShopNums.Add(shopNum);
-                    } else {
-                        TunicLogger.LogInfo($"Was missing {portalName} in ItemTracker.WriteEntranceFile, we should investigate this");
-                    }
-                }
-            }
-
-            leftoverShopNums.Sort();
-
-            foreach (int num in leftoverShopNums) {
-                addPortal($"Shop Portal {num}", "Shop");
+            List<string> leftoverPortals = allInUsePortalNames.Where(x => !addedPortals.Contains(x) && x.StartsWith("Shop")).OrderBy(x => int.Parse(x.Split(' ').Last())).ToList();
+            foreach (string shopPortal in leftoverPortals) {
+                addPortal(shopPortal, "Shop");
             }
 
             fileContents = "From,,To\n";

--- a/src/Data/ItemTracker.cs
+++ b/src/Data/ItemTracker.cs
@@ -193,13 +193,13 @@ namespace TunicRandomizer {
         }
 
         public void PopulateDiscoveredEntrances() {
-            foreach (KeyValuePair<string, PortalCombo> portalCombo in ERData.RandomizedPortals) {
-                if (SaveFile.GetInt("randomizer entered portal " + portalCombo.Value.Portal1.Name) == 1) {
-                    DiscoveredEntrances[portalCombo.Value.Portal1.SceneDestinationTag] = portalCombo.Value.Portal2.SceneDestinationTag;
+            foreach (PortalCombo portalCombo in ERData.RandomizedPortals.Values) {
+                if (SaveFile.GetInt("randomizer entered portal " + portalCombo.Portal1.Name) == 1) {
+                    DiscoveredEntrances[portalCombo.Portal1.SceneDestinationTag] = portalCombo.Portal2.SceneDestinationTag;
                 }
                 if (!GetBool(Decoupled)) {
-                    if (SaveFile.GetInt("randomizer entered portal " + portalCombo.Value.Portal2.Name) == 1) {
-                        DiscoveredEntrances[portalCombo.Value.Portal2.SceneDestinationTag] = portalCombo.Value.Portal1.SceneDestinationTag;
+                    if (SaveFile.GetInt("randomizer entered portal " + portalCombo.Portal2.Name) == 1) {
+                        DiscoveredEntrances[portalCombo.Portal2.SceneDestinationTag] = portalCombo.Portal1.SceneDestinationTag;
                     }
                 }
             }
@@ -209,16 +209,18 @@ namespace TunicRandomizer {
             SaveTrackerFile();
         }
 
+        public static List<PortalCombo> EntranceFileAllPortals = new List<PortalCombo>();
         public void WriteEntranceFile() {
             string fileContents = "";
 
+            List<string> allInUsePortalNames = new List<string>();
+
+            allInUsePortalNames = ERData.RandomizedPortals.Select(p => p.Value.Portal1.Name).ToList();
+
             Dictionary<string, PortalCombo> portalNameToPair = new Dictionary<string, PortalCombo>();
-            int numberOfShops = 0;
+
             foreach (PortalCombo portalCombo in ERData.RandomizedPortals.Values) {
                 portalNameToPair.Add(portalCombo.Portal1.Name, portalCombo);
-                if (portalCombo.Portal1.Name.Contains("Shop Portal")) {
-                    numberOfShops++;
-                }
             }
 
             Dictionary<string, List<string>> regionsToPortals = new Dictionary<string, List<string>>();
@@ -239,13 +241,9 @@ namespace TunicRandomizer {
                 }
                 foreach (List<ERData.TunicPortal> portalList in portalGroup.Value.Values) {
                     foreach (ERData.TunicPortal portal in portalList) {
-                        if (portalNameToPair.ContainsKey(portal.Name)) {
+                        if (allInUsePortalNames.Contains(portal.Name)) {
                             addPortal(portal.Name, portalGroup.Key);
-                        } else if (portal.Name == "Shop Portal") {
-                            for (int i = 0; i < numberOfShops; i++) {
-                                addPortal($"{portal.Name} {i+1}", portalGroup.Key);
-                            }
-                        }                        
+                        }
                     }
                 }
             }

--- a/src/Data/Portal.cs
+++ b/src/Data/Portal.cs
@@ -46,6 +46,10 @@ namespace TunicRandomizer {
 
         // for portals that lead directly to a different region, ie: appearing at a yellow portal square
         public string OutletRegion() {
+            // for shop portals past number 8, we need an override here
+            if (Region.StartsWith("Shop") && !ERData.RegionDict.ContainsKey(Region)) {
+                return Region;
+            }
             return ERData.RegionDict[Region].OutletRegion ?? Region;
         }
     }

--- a/src/Patches/ERScripts.cs
+++ b/src/Patches/ERScripts.cs
@@ -117,7 +117,7 @@ namespace TunicRandomizer {
                     dir = (int)PDir.EAST;
                 }
                 if (portal2_sdt.StartsWith("Shop,")) {
-                    portal2 = new Portal(name: "Shop Portal", destination: $"Previous Region {shop_num}", tag: "", scene: "Shop", region: $"Shop Entrance {shop_num}", direction: dir);
+                    portal2 = new Portal(name: $"Shop Portal {shop_num}", destination: $"Previous Region {shop_num}", tag: "", scene: "Shop", region: $"Shop Entrance {shop_num}", direction: dir);
                     shop_num++;
                 }
                 else if (portal2_sdt == "Purgatory, Purgatory_bottom") {


### PR DESCRIPTION
Fixes extra shops that show up from AP runs.

Shops are now consistently numbered in single player too as a result.