### PR TITLE
Force laurels to not show up at terrible places in Fox Prince

### DIFF
--- a/src/Patches/ERScripts.cs
+++ b/src/Patches/ERScripts.cs
@@ -18,12 +18,6 @@ namespace TunicRandomizer {
             if (modifiedTraversalReqs == null) {
                 modifiedTraversalReqs = ModifiedTraversalReqs;
             }
-            if (TunicLogger.Testing) {
-                TunicLogger.LogTesting("Starting UpdateReachableRegions, current inventory is as follows:");
-                foreach (string itemName in inventory.Keys) {
-                    TunicLogger.LogTesting(itemName);
-                }
-            }
             int inv_count = inventory.Count;
 
             // this is basically if it uses trick logic to get somewhere and never goes and back-checks it later after getting laurels

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -456,7 +456,7 @@ namespace TunicRandomizer {
 
                 int counter = 0;
                 while (!InitialLocations[l].reachable(FullInventory) 
-                    || (item.Name == "Hyperdash" && InitialLocations[l].LocationId == "1007" && GetBool(FoxPrinceEnabled) == true)) {  // if laurels is at 20 fairies, fox prince freaks the hell out most of the time, so let's just avoid it
+                    || (item.Name == "Hyperdash" && InitialLocations[l].LocationId == "1007" && GetBool(FoxPrinceEnabled))) {  // if laurels is at 20 fairies, fox prince freaks the hell out most of the time, so let's just avoid it
                     l = random.Next(InitialLocations.Count);
                     counter++;
                     // If it fails to place an item, start over with the current seed progress

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -455,7 +455,8 @@ namespace TunicRandomizer {
                 l = random.Next(InitialLocations.Count);
 
                 int counter = 0;
-                while (!InitialLocations[l].reachable(FullInventory) || (item.Name == "Hyperdash" && InitialLocations[l].LocationId == "1007" && GetBool(FoxPrinceEnabled) == true)) {
+                while (!InitialLocations[l].reachable(FullInventory) 
+                    || (item.Name == "Hyperdash" && InitialLocations[l].LocationId == "1007" && GetBool(FoxPrinceEnabled) == true)) {  // if laurels is at 20 fairies, fox prince freaks the hell out most of the time, so let's just avoid it
                     l = random.Next(InitialLocations.Count);
                     counter++;
                     // If it fails to place an item, start over with the current seed progress

--- a/src/Patches/ItemRandomizer.cs
+++ b/src/Patches/ItemRandomizer.cs
@@ -455,7 +455,7 @@ namespace TunicRandomizer {
                 l = random.Next(InitialLocations.Count);
 
                 int counter = 0;
-                while (!InitialLocations[l].reachable(FullInventory)) {
+                while (!InitialLocations[l].reachable(FullInventory) || (item.Name == "Hyperdash" && InitialLocations[l].LocationId == "1007" && GetBool(FoxPrinceEnabled) == true)) {
                     l = random.Next(InitialLocations.Count);
                     counter++;
                     // If it fails to place an item, start over with the current seed progress

--- a/src/Util/TunicLogger.cs
+++ b/src/Util/TunicLogger.cs
@@ -26,7 +26,7 @@ namespace TunicRandomizer {
         }
 
         // set this to true to trigger logging for all log testing messages
-        public static bool Testing = true;
+        public static bool Testing = false;
         public static void LogTesting(string message) {
             if (Testing) {
                 Logger.LogInfo(message);

--- a/src/Util/TunicLogger.cs
+++ b/src/Util/TunicLogger.cs
@@ -26,7 +26,7 @@ namespace TunicRandomizer {
         }
 
         // set this to true to trigger logging for all log testing messages
-        public static bool Testing = false;
+        public static bool Testing = true;
         public static void LogTesting(string message) {
             if (Testing) {
                 Logger.LogInfo(message);


### PR DESCRIPTION
Basically so that Fox Prince doesn't freak the hell out when it tries to do a very very particular entrance randomization for a restrictive item placement