### PR TITLE
Fix decoupled dying in phase 2 to deplando'd portals

### DIFF
--- a/src/Patches/ERScripts.cs
+++ b/src/Patches/ERScripts.cs
@@ -772,7 +772,8 @@ namespace TunicRandomizer {
                     portalsList.Add(portal1);
                     portalsList2.Add(portal2);
                     TunicUtils.ShuffleList(portalsList, seed);
-                    TunicUtils.ShuffleList(portalsList2, seed);
+                    // if there isn't a different seed here, the lists will both shuffle the same way, so the deplando'd portals will keep hitting each other
+                    TunicUtils.ShuffleList(portalsList2, seed + 1);
                     continue;
                 }
 


### PR DESCRIPTION
Basically it was shuffling both lists in a seeded way, so both of them were shuffling the two parts of the errant pair to the same spots in both lists, so they would always eventually end up together