### PR TITLE
Fox Prince: Dynamic Trial Count

### DIFF
--- a/src/Patches/ERScripts.cs
+++ b/src/Patches/ERScripts.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using JetBrains.Annotations;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -392,12 +393,6 @@ namespace TunicRandomizer {
                         string destination = SaveFile.stringStore[key];
                         Portal portal1 = portalsList.First(portal => portal.Name == origin);
                         Portal portal2 = portalsList.First(portal => portal.Name == destination);
-                        // if we end up having to redo RandomizePortals during initial generation, we end up adding this portal twice, which breaks stuff
-                        foreach (PortalCombo portalCombo in FoxPrince.FPRandomizedPortals) {
-                            if (portalCombo.Portal1.Name == portal1.Name && portalCombo.Portal2.Name == portal2.Name) {
-                                continue;
-                            }
-                        }
                         FoxPrince.FPRandomizedPortals.Add(new PortalCombo(portal1, portal2));
                     }
                 }
@@ -450,6 +445,12 @@ namespace TunicRandomizer {
                 } else {
                     twoPlusPortalDirectionTracker[portal2.Direction]--;
                 }
+            }
+
+            // this is to keep track of how many portals are left in the pool, so we can dynamically reduce the retry count to make late game load choices faster
+            FoxPrince.PortalsLeftInPool = portalsList.Count + portalsList2.Count;
+            foreach (KeyValuePair<int, int> kvp in twoPlusPortalDirectionTracker) {
+                FoxPrince.DirTracker[kvp.Key] = kvp.Value + deadEndPortalDirectionTracker[kvp.Key];
             }
 
             // add the plando'd connections to the traversal reqs
@@ -509,7 +510,7 @@ namespace TunicRandomizer {
                 if (region.Key.StartsWith("LS Elev") && SaveFile.GetInt(LadderStorageDifficulty) == 0) continue;
                 allRegions.Add(region.Key);
             }
-
+            
             while (FullInventory.Keys.Where(region => RegionDict.ContainsKey(region) && !RegionDict[region].SkipCounting).ToList().Count < allRegions.Count()) {
                 Portal portal1 = null;
                 Portal portal2 = null;

--- a/src/Patches/ERScripts.cs
+++ b/src/Patches/ERScripts.cs
@@ -510,7 +510,7 @@ namespace TunicRandomizer {
                 if (region.Key.StartsWith("LS Elev") && SaveFile.GetInt(LadderStorageDifficulty) == 0) continue;
                 allRegions.Add(region.Key);
             }
-            
+
             while (FullInventory.Keys.Where(region => RegionDict.ContainsKey(region) && !RegionDict[region].SkipCounting).ToList().Count < allRegions.Count()) {
                 Portal portal1 = null;
                 Portal portal2 = null;

--- a/src/Patches/FoxPrince.cs
+++ b/src/Patches/FoxPrince.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using static TunicRandomizer.ERScripts;
@@ -18,6 +17,9 @@ namespace TunicRandomizer {
         // so we aren't just reading them off the save file every time
         // this might be overengineering it though, idk
         public static Dictionary<string, string> CachedPlandoPortals = new Dictionary<string, string>();
+        // these are to see how many portals are left in the pool, so we can reduce the retry count dynamically
+        public static int PortalsLeftInPool = 440;
+        public static Dictionary<int, int> DirTracker = new Dictionary<int, int>();
 
         // for use with the pin system
         public static string PinnedPortal {
@@ -144,11 +146,31 @@ namespace TunicRandomizer {
             // we want to fine tune this to try to get 3 different portals when possible, but not take overly long if there aren't 3+ possibilities
             int maxTrialCount = 1000;
             int trialCount = 0;
+
+            // this is a little sloppy, it's mostly so that we update PortalsLeftInPool and DirTracker
+            List<PortalCombo> portalsForCounting = RandomizePortals(seed, plando, deplando, canFail: true);
+            // we're adjusting max trial count based on how many potential portals are left in the pool
+            // in practice, if there's a high portal count left, it'll probably never get through a handful of portals before it gets to 3
+            // at low portal counts, it'll probably never need more than a few dozen trials
+            int potentialValidPortalsLeft;
+            if (GetBool(PortalDirectionPairs)) {
+                int portalDir = TunicUtils.FindPortalDirectionFromName(currentPortalName);
+                potentialValidPortalsLeft = DirTracker[TunicUtils.DirectionPairs[portalDir]];
+            } else {
+                potentialValidPortalsLeft = PortalsLeftInPool;
+            }
+            // this equation is entirely based on vibes
+            maxTrialCount = potentialValidPortalsLeft * 5 + 20;
+
             while (portalChoices.Count < 3) {
                 if (trialCount >= maxTrialCount && (portalChoices.Count > 0 || excludedPortals != null)) {
                     // we've done enough trials to say that we probably won't find any more connections, so it's time to give the player less than 3 choices
                     // if we don't have any choices yet, keep trying -- if it's failing, we'd wanna know that, but maybe it's just something really restrictive and weird
                     // if there's excluded portals, that's because they rerolled, so they'll just need to get a set of old portals now
+                    break;
+                }
+                if (potentialValidPortalsLeft == portalChoices.Count) {
+                    // we've already found all the portals possible, so let's just break it now and save a quarter second
                     break;
                 }
                 trialCount++;
@@ -165,7 +187,6 @@ namespace TunicRandomizer {
 
                 TunicLogger.LogTesting("portal choice is " + newPortalCombo.Portal2.Name);
 
-                // todo: remove this later when confident that it's not going to be a problem
                 TunicLogger.LogTesting($"Starting check all reachable in trials for {newPortalCombo.Portal2.Name}");
                 TunicUtils.CheckAllLocsReachable(randomizedPortals);
 


### PR DESCRIPTION
This makes it so that the max number of trials it'll run when finding portals is 5 * the number of potentially valid portals left in the pool + 20.

"Potentially valid portals left in the pool" means any portal for non-direction pairs, and means the number of opposite-direction portals for direction pairs.

Also gave it an even earlier out if the number of potentially valid portals in the pool equals the number of portals that have been confirmed for the pick 3, so that it just runs a little smoother when you have 1 or 2 valid choices for a portal.